### PR TITLE
[CHK-912] feat(privacy): add `Confidential<T>` class to handle sensitive data

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
@@ -31,7 +31,7 @@ public record AESMetadata(
     /**
      * The length of the initialization vector
      */
-    public final static int IV_LENGTH = 12;
+    public static final int IV_LENGTH = 12;
 
     /**
      * The length of the salt

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
@@ -12,6 +12,14 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Objects;
 
+/**
+ * <p>
+ * AES metadata.
+ * </p>
+ *
+ * @param salt the salt used during encryption
+ * @param iv   the initialization vector used during encryption
+ */
 @JsonIgnoreProperties(value = "mode")
 public record AESMetadata(
         @Nonnull byte[] salt,
@@ -20,7 +28,14 @@ public record AESMetadata(
         implements
         ConfidentialMetadata {
 
+    /**
+     * The length of the initialization vector
+     */
     public final static int IV_LENGTH = 12;
+
+    /**
+     * The length of the salt
+     */
     public static final int SALT_LENGTH = 16;
 
     @JsonCreator
@@ -31,12 +46,19 @@ public record AESMetadata(
         this(Base64.getDecoder().decode(salt), new IvParameterSpec(Base64.getDecoder().decode(iv)));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Nonnull
     @Override
     public ConfidentialDataManager.Mode getMode() {
         return ConfidentialDataManager.Mode.AES_GCM_NOPAD;
     }
 
+    /**
+     * Default constructor. Generates a {@link AESMetadata} with a randomly
+     * generated salt and a randomly generated IV.
+     */
     public AESMetadata() {
         this(generateSalt(), generateIv());
     }

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
@@ -43,7 +43,7 @@ public record AESMetadata(
             @JsonProperty("salt") String salt,
             @JsonProperty("iv") String iv
     ) {
-        this(Base64.getDecoder().decode(salt), new IvParameterSpec(Base64.getDecoder().decode(iv)));
+        this(Base64.getDecoder().decode(salt), new IvParameterSpec(Base64.getDecoder().decode(iv))); // NOSONAR
     }
 
     /**

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
@@ -16,14 +16,20 @@ import java.util.Objects;
 public record AESMetadata(
         @Nonnull byte[] salt,
         @Nonnull IvParameterSpec iv
-) implements ConfidentialMetadata {
+)
+        implements
+        ConfidentialMetadata {
+
     public final static int IV_LENGTH = 12;
     public static final int SALT_LENGTH = 16;
 
     @JsonCreator
-    private AESMetadata(@JsonProperty("salt") String salt, @JsonProperty("iv") String iv) {
+    private AESMetadata(
+            @JsonProperty("salt") String salt,
+            @JsonProperty("iv") String iv
+    ) {
         this(Base64.getDecoder().decode(salt), new IvParameterSpec(Base64.getDecoder().decode(iv)));
-}
+    }
 
     @Nonnull
     @Override

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
@@ -75,6 +75,14 @@ public record AESMetadata(
         return Objects.hash(Arrays.hashCode(salt), Arrays.hashCode(iv.getIV()));
     }
 
+    @Override
+    public String toString() {
+        return "AESMetadata{" +
+                "salt=" + Arrays.toString(salt) +
+                ", iv=" + iv +
+                '}';
+    }
+
     @Nonnull
     private static IvParameterSpec generateIv() {
         SecureRandom secureRandom = new SecureRandom();

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
@@ -1,0 +1,81 @@
+package it.pagopa.ecommerce.commons.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
+
+import javax.annotation.Nonnull;
+import javax.crypto.spec.IvParameterSpec;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Objects;
+
+@JsonIgnoreProperties(value = "mode")
+public record AESMetadata(
+        @Nonnull byte[] salt,
+        @Nonnull IvParameterSpec iv
+) implements ConfidentialMetadata {
+    public final static int IV_LENGTH = 12;
+    public static final int SALT_LENGTH = 16;
+
+    @JsonCreator
+    private AESMetadata(@JsonProperty("salt") String salt, @JsonProperty("iv") String iv) {
+        this(Base64.getDecoder().decode(salt), new IvParameterSpec(Base64.getDecoder().decode(iv)));
+}
+
+    @Nonnull
+    @Override
+    public ConfidentialDataManager.Mode getMode() {
+        return ConfidentialDataManager.Mode.AES_GCM_NOPAD;
+    }
+
+    public AESMetadata() {
+        this(generateSalt(), generateIv());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof AESMetadata other
+                && Arrays.equals(salt, other.salt)
+                && Arrays.equals(iv.getIV(), other.iv.getIV());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Arrays.hashCode(salt), Arrays.hashCode(iv.getIV()));
+    }
+
+    @Nonnull
+    private static IvParameterSpec generateIv() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] iv = new byte[IV_LENGTH];
+
+        secureRandom.nextBytes(iv);
+
+        return new IvParameterSpec(iv);
+    }
+
+    @Nonnull
+    private static byte[] generateSalt() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] salt = new byte[SALT_LENGTH];
+
+        secureRandom.nextBytes(salt);
+
+        return salt;
+    }
+
+    @Nonnull
+    @JsonProperty("iv")
+    private String getEncodedIv() {
+        return Base64.getEncoder().encodeToString(iv.getIV());
+    }
+
+    @Nonnull
+    @JsonProperty("salt")
+    private String getEncodedSalt() {
+        return Base64.getEncoder().encodeToString(salt);
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/Confidential.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/Confidential.java
@@ -9,10 +9,11 @@ import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
  * An object holding confidential data.
  * </p>
  */
-public record Confidential<T extends ConfidentialDataManager.ConfidentialData>(
+public record Confidential<T extends ConfidentialDataManager.ConfidentialData> (
         @JsonProperty("metadata") ConfidentialMetadata confidentialMetadata,
         @JsonProperty("data") String encodedCipherText
 ) {
     @JsonCreator
-    public Confidential {}
+    public Confidential {
+    }
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/Confidential.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/Confidential.java
@@ -10,6 +10,16 @@ import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
  * to get the original data back.
  * </p>
  */
+/*
+ * @formatter:off
+ *
+ * Warning java:S2326 - T is not used in the record.
+ * Suppressed because the whole point of this class is to mimic "as if"
+ * an encrypted `T` was present and handle it transparently
+ *
+ * @formatter:on
+ */
+@SuppressWarnings("java:S2326")
 public record Confidential<T extends ConfidentialDataManager.ConfidentialData> (
         @JsonProperty("metadata") ConfidentialMetadata confidentialMetadata,
         @JsonProperty("data") String opaqueData
@@ -22,7 +32,23 @@ public record Confidential<T extends ConfidentialDataManager.ConfidentialData> (
      * @param opaqueData           opaque data (e.g. a ciphertext, a token to an
      *                             external service, etc.)
      */
+    /*
+     * @formatter:off
+     *
+     * Warning java:S1186 - Methods should not be empty
+     * Warning java:S6207 - Redundant constructors/methods should be avoided in records
+     * Both suppressed because this constructor is just to add the `@JsonCreator` annotation
+     * and is currently the canonical way to add annotations to record constructors
+     *
+     * @formatter:on
+     */
     @JsonCreator
+    @SuppressWarnings(
+        {
+                "java:S1186",
+                "java:S6207"
+        }
+    )
     public Confidential {
     }
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/Confidential.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/Confidential.java
@@ -6,13 +6,22 @@ import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
 
 /**
  * <p>
- * An object holding confidential data.
+ * An object holding confidential opaque data, along with the necessary metadata
+ * to get the original data back.
  * </p>
  */
 public record Confidential<T extends ConfidentialDataManager.ConfidentialData> (
         @JsonProperty("metadata") ConfidentialMetadata confidentialMetadata,
-        @JsonProperty("data") String encodedCipherText
+        @JsonProperty("data") String opaqueData
 ) {
+    /**
+     * Constructs a {@link Confidential} from existing data
+     *
+     * @param confidentialMetadata metadata about how this confidential data was
+     *                             protected
+     * @param opaqueData           opaque data (e.g. a ciphertext, a token to an
+     *                             external service, etc.)
+     */
     @JsonCreator
     public Confidential {
     }

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/Confidential.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/Confidential.java
@@ -1,72 +1,18 @@
 package it.pagopa.ecommerce.commons.domain;
 
-import javax.crypto.*;
-import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.PBEKeySpec;
-import javax.crypto.spec.SecretKeySpec;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.KeySpec;
-import java.util.Base64;
-import java.util.function.Function;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
 
 /**
  * <p>
  * An object holding confidential data.
- * This data is encrypted using AES
  * </p>
  */
-public class Confidential {
-    private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
-
-    private final String encodedCipherText;
-    private final IvParameterSpec iv;
-    private final SecretKey key;
-
-    public Confidential(String confidentialData) throws IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidAlgorithmParameterException, InvalidKeyException {
-        this.iv = generateIv();
-        this.key = getKeyFromPassword(confidentialData, "salt");
-
-        Cipher cipher = Cipher.getInstance(ALGORITHM);
-        cipher.init(Cipher.ENCRYPT_MODE, key, iv);
-        byte[] cipherText = cipher.doFinal(confidentialData.getBytes());
-
-        this.encodedCipherText = Base64.getEncoder().encodeToString(cipherText);
-    }
-
-    private static SecretKey getKeyFromPassword(String password, String salt)
-            throws NoSuchAlgorithmException, InvalidKeySpecException {
-
-        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-        KeySpec spec = new PBEKeySpec(password.toCharArray(), salt.getBytes(), 65536, 256);
-        return new SecretKeySpec(factory.generateSecret(spec).getEncoded(), "AES");
-    }
-
-    private static IvParameterSpec generateIv() {
-        byte[] iv = new byte[16];
-        new SecureRandom().nextBytes(iv);
-        return new IvParameterSpec(iv);
-    }
-
-    private String decrypt(String cipherText) throws NoSuchPaddingException, NoSuchAlgorithmException,
-            InvalidAlgorithmParameterException, InvalidKeyException,
-            BadPaddingException, IllegalBlockSizeException {
-
-        Cipher cipher = Cipher.getInstance(ALGORITHM);
-        cipher.init(Cipher.DECRYPT_MODE, this.key, this.iv);
-        byte[] plainText = cipher.doFinal(Base64.getDecoder().decode(cipherText));
-
-        return new String(plainText);
-    }
-
-    public <D> D decrypt(Function<String, D> constructor) throws InvalidAlgorithmParameterException, NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
-        return constructor.apply(decrypt(this.encodedCipherText));
-    }
-
-    public String getEncodedCipherText() {
-        return encodedCipherText;
-    }
+public record Confidential<T extends ConfidentialDataManager.ConfidentialData>(
+        @JsonProperty("metadata") ConfidentialMetadata confidentialMetadata,
+        @JsonProperty("data") String encodedCipherText
+) {
+    @JsonCreator
+    public Confidential {}
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/Confidential.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/Confidential.java
@@ -1,0 +1,72 @@
+package it.pagopa.ecommerce.commons.domain;
+
+import javax.crypto.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.Base64;
+import java.util.function.Function;
+
+/**
+ * <p>
+ * An object holding confidential data.
+ * This data is encrypted using AES
+ * </p>
+ */
+public class Confidential {
+    private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
+
+    private final String encodedCipherText;
+    private final IvParameterSpec iv;
+    private final SecretKey key;
+
+    public Confidential(String confidentialData) throws IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidAlgorithmParameterException, InvalidKeyException {
+        this.iv = generateIv();
+        this.key = getKeyFromPassword(confidentialData, "salt");
+
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.ENCRYPT_MODE, key, iv);
+        byte[] cipherText = cipher.doFinal(confidentialData.getBytes());
+
+        this.encodedCipherText = Base64.getEncoder().encodeToString(cipherText);
+    }
+
+    private static SecretKey getKeyFromPassword(String password, String salt)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+        KeySpec spec = new PBEKeySpec(password.toCharArray(), salt.getBytes(), 65536, 256);
+        return new SecretKeySpec(factory.generateSecret(spec).getEncoded(), "AES");
+    }
+
+    private static IvParameterSpec generateIv() {
+        byte[] iv = new byte[16];
+        new SecureRandom().nextBytes(iv);
+        return new IvParameterSpec(iv);
+    }
+
+    private String decrypt(String cipherText) throws NoSuchPaddingException, NoSuchAlgorithmException,
+            InvalidAlgorithmParameterException, InvalidKeyException,
+            BadPaddingException, IllegalBlockSizeException {
+
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.DECRYPT_MODE, this.key, this.iv);
+        byte[] plainText = cipher.doFinal(Base64.getDecoder().decode(cipherText));
+
+        return new String(plainText);
+    }
+
+    public <D> D decrypt(Function<String, D> constructor) throws InvalidAlgorithmParameterException, NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
+        return constructor.apply(decrypt(this.encodedCipherText));
+    }
+
+    public String getEncodedCipherText() {
+        return encodedCipherText;
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "mode", visible = true)
 @JsonSubTypes(
     {
-            @JsonSubTypes.Type(value = AESMetadata.class, name = "AES/GCM/NoPadding"),
+            @JsonSubTypes.Type(value = AESMetadata.class, name = "AES_GCM_NOPAD"),
     }
 )
 public sealed interface ConfidentialMetadata permits AESMetadata {

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
@@ -9,9 +9,12 @@ import javax.annotation.Nonnull;
 
 @JsonIgnoreProperties(value = "mode")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "mode", visible = true)
-@JsonSubTypes({
-        @JsonSubTypes.Type(value = AESMetadata.class, name = "AES/GCM/NoPadding"),
-})
+@JsonSubTypes(
+    {
+            @JsonSubTypes.Type(value = AESMetadata.class, name = "AES/GCM/NoPadding"),
+    }
+)
 public sealed interface ConfidentialMetadata permits AESMetadata {
-    @Nonnull ConfidentialDataManager.Mode getMode();
+    @Nonnull
+    ConfidentialDataManager.Mode getMode();
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
@@ -7,6 +7,12 @@ import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
 
 import javax.annotation.Nonnull;
 
+/**
+ * <p>
+ * A sealed interface for confidential metadata. Each metadata variant is
+ * identified through a different {@link ConfidentialDataManager.Mode Mode}
+ * </p>
+ */
 @JsonIgnoreProperties(value = "mode")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "mode", visible = true)
 @JsonSubTypes(
@@ -15,6 +21,11 @@ import javax.annotation.Nonnull;
     }
 )
 public sealed interface ConfidentialMetadata permits AESMetadata {
+    /**
+     * Gets the mode identifying the metadata
+     *
+     * @return the mode
+     */
     @Nonnull
     ConfidentialDataManager.Mode getMode();
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
@@ -1,0 +1,17 @@
+package it.pagopa.ecommerce.commons.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
+
+import javax.annotation.Nonnull;
+
+@JsonIgnoreProperties(value = "mode")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "mode", visible = true)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = AESMetadata.class, name = "AES/GCM/NoPadding"),
+})
+public sealed interface ConfidentialMetadata permits AESMetadata {
+    @Nonnull ConfidentialDataManager.Mode getMode();
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v1/Email.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v1/Email.java
@@ -18,7 +18,9 @@ import java.util.regex.Pattern;
  * @param value email address
  */
 @ValueObject
-public record Email(String value) implements ConfidentialDataManager.ConfidentialData {
+public record Email(String value)
+        implements
+        ConfidentialDataManager.ConfidentialData {
     private static final Pattern emailRegex = Pattern.compile(
             "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])" // NOSONAR
     );

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v1/Email.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v1/Email.java
@@ -1,7 +1,9 @@
 package it.pagopa.ecommerce.commons.domain.v1;
 
 import it.pagopa.ecommerce.commons.annotations.ValueObject;
+import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
 
+import javax.annotation.Nonnull;
 import java.util.regex.Pattern;
 
 /**
@@ -16,7 +18,7 @@ import java.util.regex.Pattern;
  * @param value email address
  */
 @ValueObject
-public record Email(String value) {
+public record Email(String value) implements ConfidentialDataManager.ConfidentialData {
     private static final Pattern emailRegex = Pattern.compile(
             "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])" // NOSONAR
     );
@@ -33,5 +35,11 @@ public record Email(String value) {
                     "Ill-formed email: " + value + ". Doesn't match format: " + emailRegex.pattern()
             );
         }
+    }
+
+    @Nonnull
+    @Override
+    public String toStringRepresentation() {
+        return value;
     }
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/AESCipher.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/AESCipher.java
@@ -1,0 +1,53 @@
+package it.pagopa.ecommerce.commons.utils;
+
+import it.pagopa.ecommerce.commons.domain.AESMetadata;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+
+public class AESCipher {
+    private static final int GCM_TAG_BIT_LENGTH = 128;
+    private final SecretKeySpec key;
+
+    public AESCipher(SecretKeySpec key) {
+        this.key = key;
+    }
+
+    public String encrypt(AESMetadata aesMetadata, String data) throws IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException {
+        Cipher cipher = Cipher.getInstance(aesMetadata.getMode().value);
+        GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_BIT_LENGTH, aesMetadata.iv().getIV());
+        cipher.init(Cipher.ENCRYPT_MODE, key, parameterSpec);
+        byte[] cipherText = cipher.doFinal(concatBytes(data.getBytes(), aesMetadata.salt()));
+
+        return Base64.getEncoder().encodeToString(cipherText);
+    }
+
+    public String decrypt(AESMetadata aesMetadata, String cipherText) throws NoSuchPaddingException, NoSuchAlgorithmException,
+            InvalidAlgorithmParameterException, InvalidKeyException,
+            BadPaddingException, IllegalBlockSizeException {
+
+        Cipher cipher = Cipher.getInstance(aesMetadata.getMode().value);
+        GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_BIT_LENGTH, aesMetadata.iv().getIV());
+        cipher.init(Cipher.DECRYPT_MODE, key, parameterSpec);
+
+        byte[] decipheredData = cipher.doFinal(Base64.getDecoder().decode(cipherText));
+        byte[] plainText = Arrays.copyOfRange(decipheredData, 0, decipheredData.length - aesMetadata.salt().length);
+
+        return new String(plainText);
+    }
+
+    private static byte[] concatBytes(byte[] array1, byte[] array2) {
+        byte[] result = Arrays.copyOf(array1, array1.length + array2.length);
+        System.arraycopy(array2, 0, result, array1.length, array2.length);
+        return result;
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/AESCipher.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/AESCipher.java
@@ -22,7 +22,11 @@ public class AESCipher {
         this.key = key;
     }
 
-    public String encrypt(AESMetadata aesMetadata, String data) throws IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException {
+    public String encrypt(
+                          AESMetadata aesMetadata,
+                          String data
+    ) throws IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, NoSuchAlgorithmException,
+            InvalidAlgorithmParameterException, InvalidKeyException {
         Cipher cipher = Cipher.getInstance(aesMetadata.getMode().value);
         GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_BIT_LENGTH, aesMetadata.iv().getIV());
         cipher.init(Cipher.ENCRYPT_MODE, key, parameterSpec);
@@ -33,14 +37,16 @@ public class AESCipher {
         return Base64.getEncoder().encodeToString(cipherText);
     }
 
-    public String decrypt(AESMetadata aesMetadata, String cipherText) throws NoSuchPaddingException, NoSuchAlgorithmException,
+    public String decrypt(
+                          AESMetadata aesMetadata,
+                          String cipherText
+    ) throws NoSuchPaddingException, NoSuchAlgorithmException,
             InvalidAlgorithmParameterException, InvalidKeyException,
             BadPaddingException, IllegalBlockSizeException {
 
         Cipher cipher = Cipher.getInstance(aesMetadata.getMode().value);
         GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_BIT_LENGTH, aesMetadata.iv().getIV());
         cipher.init(Cipher.DECRYPT_MODE, key, parameterSpec);
-
 
         cipher.updateAAD(aesMetadata.iv().getIV());
 
@@ -50,7 +56,10 @@ public class AESCipher {
         return new String(plainText);
     }
 
-    private static byte[] concatBytes(byte[] array1, byte[] array2) {
+    private static byte[] concatBytes(
+                                      byte[] array1,
+                                      byte[] array2
+    ) {
         byte[] result = Arrays.copyOf(array1, array1.length + array2.length);
         System.arraycopy(array2, 0, result, array1.length, array2.length);
         return result;

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/AESCipher.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/AESCipher.java
@@ -14,14 +14,40 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
 
+/**
+ * <p>
+ * Utility class implementing AES encryption.
+ * </p>
+ * <p>
+ * Currently supports only GCM mode.
+ * </p>
+ */
 public class AESCipher {
     private static final int GCM_TAG_BIT_LENGTH = 128;
     private final SecretKeySpec key;
 
+    /**
+     * Constructs a cipher with the given secret key
+     *
+     * @param key the AES secret key
+     */
     public AESCipher(SecretKeySpec key) {
         this.key = key;
     }
 
+    /**
+     * Encrypts a piece of data
+     *
+     * @param aesMetadata algorithm metadata
+     * @param data        the data to be encrypted
+     * @return the encrypted data
+     * @throws IllegalBlockSizeException          See {@link Cipher#doFinal(byte[])}
+     * @throws BadPaddingException                See {@link Cipher#doFinal(byte[])}
+     * @throws NoSuchPaddingException             See {@link Cipher#doFinal(byte[])}
+     * @throws NoSuchAlgorithmException           See {@link Cipher#doFinal(byte[])}
+     * @throws InvalidAlgorithmParameterException See {@link Cipher#doFinal(byte[])}
+     * @throws InvalidKeyException                See {@link Cipher#doFinal(byte[])}
+     */
     public String encrypt(
                           AESMetadata aesMetadata,
                           String data
@@ -37,6 +63,20 @@ public class AESCipher {
         return Base64.getEncoder().encodeToString(cipherText);
     }
 
+    /**
+     * Decrypts a piece of encrypted data
+     *
+     * @param aesMetadata algorithm metadata. Must match the metadata used during
+     *                    encryption.
+     * @param cipherText  the encrypted data
+     * @return the decrypted data
+     * @throws NoSuchPaddingException             See {@link Cipher#doFinal(byte[])}
+     * @throws NoSuchAlgorithmException           See {@link Cipher#doFinal(byte[])}
+     * @throws InvalidAlgorithmParameterException See {@link Cipher#doFinal(byte[])}
+     * @throws InvalidKeyException                See {@link Cipher#doFinal(byte[])}
+     * @throws BadPaddingException                See {@link Cipher#doFinal(byte[])}
+     * @throws IllegalBlockSizeException          See {@link Cipher#doFinal(byte[])}
+     */
     public String decrypt(
                           AESMetadata aesMetadata,
                           String cipherText

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/AESCipher.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/AESCipher.java
@@ -26,6 +26,8 @@ public class AESCipher {
         Cipher cipher = Cipher.getInstance(aesMetadata.getMode().value);
         GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_BIT_LENGTH, aesMetadata.iv().getIV());
         cipher.init(Cipher.ENCRYPT_MODE, key, parameterSpec);
+
+        cipher.updateAAD(aesMetadata.iv().getIV());
         byte[] cipherText = cipher.doFinal(concatBytes(data.getBytes(), aesMetadata.salt()));
 
         return Base64.getEncoder().encodeToString(cipherText);
@@ -38,6 +40,9 @@ public class AESCipher {
         Cipher cipher = Cipher.getInstance(aesMetadata.getMode().value);
         GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_BIT_LENGTH, aesMetadata.iv().getIV());
         cipher.init(Cipher.DECRYPT_MODE, key, parameterSpec);
+
+
+        cipher.updateAAD(aesMetadata.iv().getIV());
 
         byte[] decipheredData = cipher.doFinal(Base64.getDecoder().decode(cipherText));
         byte[] plainText = Arrays.copyOfRange(decipheredData, 0, decipheredData.length - aesMetadata.salt().length);

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
@@ -1,0 +1,67 @@
+package it.pagopa.ecommerce.commons.utils;
+
+import it.pagopa.ecommerce.commons.domain.AESMetadata;
+import it.pagopa.ecommerce.commons.domain.Confidential;
+import it.pagopa.ecommerce.commons.domain.ConfidentialMetadata;
+
+import javax.annotation.Nonnull;
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.function.Function;
+
+public class ConfidentialDataManager {
+    public enum Mode {
+        AES_GCM_NOPAD("AES/GCM/NoPadding");
+
+        public final String value;
+
+        Mode(String value) {
+            this.value = value;
+        }
+    }
+
+    public interface ConfidentialData {
+        @Nonnull String toStringRepresentation();
+    }
+
+    private final AESCipher aesCipher;
+
+    public ConfidentialDataManager(@Nonnull SecretKeySpec key) {
+        this.aesCipher = new AESCipher(key);
+    }
+
+    @Nonnull
+    public <T extends ConfidentialData> Confidential<T> encrypt(@Nonnull ConfidentialMetadata metadata, @Nonnull T data) throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
+        return new Confidential<T>(metadata, encryptData(metadata, data.toStringRepresentation()));
+    }
+
+    @Nonnull
+    public <T extends ConfidentialData> T decrypt(Confidential<T> data, Function<String, T> constructor) throws InvalidAlgorithmParameterException, NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
+        return constructor.apply(decrypt(data));
+    }
+
+    @Nonnull
+    public <T extends ConfidentialData> String decrypt(Confidential<T> data) throws NoSuchPaddingException, NoSuchAlgorithmException,
+            InvalidAlgorithmParameterException, InvalidKeyException,
+            BadPaddingException, IllegalBlockSizeException {
+
+        return switch (data.confidentialMetadata()) {
+            case AESMetadata aesMetadata -> this.aesCipher.decrypt(aesMetadata, data.encodedCipherText());
+            default -> throw new IllegalArgumentException("Unsupported cipher metadata!");
+        };
+    }
+
+    @Nonnull
+    private String encryptData(@Nonnull ConfidentialMetadata metadata, @Nonnull String data) throws IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidAlgorithmParameterException, InvalidKeyException {
+        return switch (metadata) {
+            case AESMetadata aesMetadata -> this.aesCipher.encrypt(aesMetadata, data);
+            default -> throw new IllegalArgumentException("Unsupported cipher metadata!");
+        };
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
@@ -27,7 +27,8 @@ public class ConfidentialDataManager {
     }
 
     public interface ConfidentialData {
-        @Nonnull String toStringRepresentation();
+        @Nonnull
+        String toStringRepresentation();
     }
 
     private final AESCipher aesCipher;
@@ -37,17 +38,28 @@ public class ConfidentialDataManager {
     }
 
     @Nonnull
-    public <T extends ConfidentialData> Confidential<T> encrypt(Mode mode, @Nonnull T data) throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
+    public <T extends ConfidentialData> Confidential<T> encrypt(
+                                                                Mode mode,
+                                                                @Nonnull T data
+    ) throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException,
+            NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
         if (mode == Mode.AES_GCM_NOPAD) {
             AESMetadata confidentialMetadata = new AESMetadata();
-            return new Confidential<T>(confidentialMetadata, encryptData(confidentialMetadata, data.toStringRepresentation()));
+            return new Confidential<T>(
+                    confidentialMetadata,
+                    encryptData(confidentialMetadata, data.toStringRepresentation())
+            );
         } else {
             throw new IllegalArgumentException();
         }
     }
 
     @Nonnull
-    public <T extends ConfidentialData> T decrypt(Confidential<T> data, Function<String, T> constructor) throws InvalidAlgorithmParameterException, NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
+    public <T extends ConfidentialData> T decrypt(
+                                                  Confidential<T> data,
+                                                  Function<String, T> constructor
+    ) throws InvalidAlgorithmParameterException, NoSuchPaddingException, IllegalBlockSizeException,
+            NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
         return constructor.apply(decrypt(data));
     }
 

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
@@ -15,10 +15,36 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.function.Function;
 
+/**
+ * <p>
+ * Class used to abstract over confidential data management and used to
+ * construct and deconstruct {@link Confidential} instances.
+ * </p>
+ * <p>
+ * This class is meant to be the entry point for an application to handle data
+ * in and out of {@link Confidential} via the
+ * {@link #encrypt(Mode, ConfidentialData)} and {@link #decrypt(Confidential)}
+ * methods
+ * </p>
+ */
 public class ConfidentialDataManager {
+    /**
+     * <p>
+     * Mode for ensuring secrecy of confidential data. Each mode corresponds to a
+     * different class implementing procedures to encrypt/mask/tokenize/etc
+     * confidential data.
+     * </p>
+     */
     public enum Mode {
+        /**
+         * This mode implements encryption with an AES cipher in GCM mode without
+         * padding. For more details, see {@link AESCipher}.
+         */
         AES_GCM_NOPAD("AES/GCM/NoPadding");
 
+        /**
+         * String representation of the mode. Must be unique for each mode.
+         */
         public final String value;
 
         Mode(String value) {
@@ -26,17 +52,62 @@ public class ConfidentialDataManager {
         }
     }
 
+    /**
+     * <p>
+     * Utility interface that handles conversions {@code T} -> {@link String}.
+     * Classes that want to be put inside a {@link Confidential} need to implement
+     * this interface, and provide a corresponding method to reconstruct instances
+     * from a string.
+     * </p>
+     */
     public interface ConfidentialData {
+        /**
+         * A function to serialize the given data. Note that the implementor is not
+         * bound to any serialization format as long as it can independently deserialize
+         * it.
+         *
+         * @return serialized data.
+         */
         @Nonnull
         String toStringRepresentation();
     }
 
     private final AESCipher aesCipher;
 
+    /**
+     * Primary constructor.
+     *
+     * @param key AES secret key used to handle
+     *            {@code ConfidentialDataManager.Mode.AES_GCM_NOPAD}
+     */
     public ConfidentialDataManager(@Nonnull SecretKeySpec key) {
         this.aesCipher = new AESCipher(key);
     }
 
+    /**
+     * Encrypts data with the given mode.
+     *
+     * @param mode the mode used to encrypt data with. See the mode details for more
+     *             information.
+     * @param data the unencrypted data
+     * @return a {@link Confidential} instance containing the encrypted data and the
+     *         algorithm metadata
+     * @param <T> type of the unencrypted data
+     * @throws InvalidAlgorithmParameterException See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws IllegalBlockSizeException          See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws NoSuchPaddingException             See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws BadPaddingException                See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws NoSuchAlgorithmException           See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws InvalidKeySpecException            See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws InvalidKeyException                See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     */
     @Nonnull
     public <T extends ConfidentialData> Confidential<T> encrypt(
                                                                 Mode mode,
@@ -54,6 +125,27 @@ public class ConfidentialDataManager {
         }
     }
 
+    /**
+     * Decrypts encrypted data.
+     *
+     * @param data        the data to be decrypted
+     * @param constructor a function to construct {@code T} instances from the
+     *                    serialized deciphered data
+     * @return a {@code T} instance built from the encrypted data
+     * @param <T> the type of the object to be returned
+     * @throws InvalidAlgorithmParameterException See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws NoSuchPaddingException             See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws IllegalBlockSizeException          See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws NoSuchAlgorithmException           See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws BadPaddingException                See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws InvalidKeyException                See
+     *                                            {@link javax.crypto.Cipher#doFinal(byte[])}
+     */
     @Nonnull
     public <T extends ConfidentialData> T decrypt(
                                                   Confidential<T> data,
@@ -63,13 +155,25 @@ public class ConfidentialDataManager {
         return constructor.apply(decrypt(data));
     }
 
+    /**
+     * Descrypts the data to string without conversion. Prefer {@link ConfidentialDataManager#decrypt(Confidential, Function)} to this.
+     * @param data the data to be decrypted
+     * @return a {@code T} instance built from the encrypted data
+     * @param <T> the type of the object to be returned
+     * @throws InvalidAlgorithmParameterException See {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws NoSuchPaddingException See {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws IllegalBlockSizeException See {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws NoSuchAlgorithmException See {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws BadPaddingException See {@link javax.crypto.Cipher#doFinal(byte[])}
+     * @throws InvalidKeyException See {@link javax.crypto.Cipher#doFinal(byte[])}
+     */
     @Nonnull
     public <T extends ConfidentialData> String decrypt(Confidential<T> data) throws NoSuchPaddingException, NoSuchAlgorithmException,
             InvalidAlgorithmParameterException, InvalidKeyException,
             BadPaddingException, IllegalBlockSizeException {
 
         return switch (data.confidentialMetadata()) {
-            case AESMetadata aesMetadata -> this.aesCipher.decrypt(aesMetadata, data.encodedCipherText());
+            case AESMetadata aesMetadata -> this.aesCipher.decrypt(aesMetadata, data.opaqueData());
             default -> throw new IllegalArgumentException("Unsupported cipher metadata!");
         };
     }

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
@@ -37,8 +37,13 @@ public class ConfidentialDataManager {
     }
 
     @Nonnull
-    public <T extends ConfidentialData> Confidential<T> encrypt(@Nonnull ConfidentialMetadata metadata, @Nonnull T data) throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
-        return new Confidential<T>(metadata, encryptData(metadata, data.toStringRepresentation()));
+    public <T extends ConfidentialData> Confidential<T> encrypt(Mode mode, @Nonnull T data) throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
+        if (mode == Mode.AES_GCM_NOPAD) {
+            AESMetadata confidentialMetadata = new AESMetadata();
+            return new Confidential<T>(confidentialMetadata, encryptData(confidentialMetadata, data.toStringRepresentation()));
+        } else {
+            throw new IllegalArgumentException();
+        }
     }
 
     @Nonnull

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/AESMetadataTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/AESMetadataTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class AESMetadataTest {
+class AESMetadataTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/AESMetadataTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/AESMetadataTest.java
@@ -23,7 +23,8 @@ public class AESMetadataTest {
         AESMetadata metadata = new AESMetadata();
 
         String serialized = objectMapper.writeValueAsString(metadata);
-        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {};
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {
+        };
         Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
 
         assertEquals(Set.of("mode", "iv", "salt"), jsonData.keySet());
@@ -35,7 +36,8 @@ public class AESMetadataTest {
 
         String serialized = objectMapper.writeValueAsString(metadata);
 
-        TypeReference<AESMetadata> typeRef = new TypeReference<>() {};
+        TypeReference<AESMetadata> typeRef = new TypeReference<>() {
+        };
         AESMetadata deserialized = objectMapper.readValue(serialized, typeRef);
 
         assertArrayEquals(metadata.salt(), deserialized.salt());

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/AESMetadataTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/AESMetadataTest.java
@@ -1,0 +1,45 @@
+package it.pagopa.ecommerce.commons.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class AESMetadataTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void aesMetadataSerializationIsOk() throws JsonProcessingException {
+        AESMetadata metadata = new AESMetadata();
+
+        String serialized = objectMapper.writeValueAsString(metadata);
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {};
+        Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
+
+        assertEquals(Set.of("mode", "iv", "salt"), jsonData.keySet());
+    }
+
+    @Test
+    void aesSerializationRoundtripIsSuccessful() throws JsonProcessingException {
+        AESMetadata metadata = new AESMetadata();
+
+        String serialized = objectMapper.writeValueAsString(metadata);
+
+        TypeReference<AESMetadata> typeRef = new TypeReference<>() {};
+        AESMetadata deserialized = objectMapper.readValue(serialized, typeRef);
+
+        assertArrayEquals(metadata.salt(), deserialized.salt());
+        assertArrayEquals(metadata.iv().getIV(), deserialized.iv().getIV());
+        assertEquals(metadata, deserialized);
+    }
+}

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
-public class ConfidentialTest {
+class ConfidentialTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ConfidentialDataManager confidentialDataManager;
 

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
@@ -3,7 +3,7 @@ package it.pagopa.ecommerce.commons.domain;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import it.pagopa.ecommerce.commons.domain.v1.Email;
 import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
 import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager.Mode;
@@ -80,11 +80,11 @@ public class ConfidentialTest {
 
         TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {};
         Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
-        jsonData.put("metadata", "{}");
+        jsonData.put("metadata", Map.of("mode", Mode.AES_GCM_NOPAD.value));
 
         String tamperedValue = objectMapper.writeValueAsString(jsonData);
         TypeReference<Confidential<Email>> confidentialEmailTypeRef = new TypeReference<>() {};
 
-        assertThrows(InvalidTypeIdException.class, () -> objectMapper.readValue(tamperedValue, confidentialEmailTypeRef));
+        assertThrows(ValueInstantiationException.class, () -> objectMapper.readValue(tamperedValue, confidentialEmailTypeRef));
     }
 }

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
@@ -41,28 +41,34 @@ public class ConfidentialTest {
     }
 
     @Test
-    void confidentialJsonRepresentationIsOK() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
+    void confidentialJsonRepresentationIsOK() throws InvalidAlgorithmParameterException, IllegalBlockSizeException,
+            NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException,
+            InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
         Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD, email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 
-        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {};
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {
+        };
         Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
 
         assertEquals(Set.of("data", "metadata"), jsonData.keySet());
     }
 
     @Test
-    void roundtripEncryptionDecryptionIsSuccessful() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
+    void roundtripEncryptionDecryptionIsSuccessful() throws InvalidAlgorithmParameterException,
+            IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException,
+            InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
         Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD, email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 
-        TypeReference<Confidential<Email>> typeRef = new TypeReference<>() {};
+        TypeReference<Confidential<Email>> typeRef = new TypeReference<>() {
+        };
         Confidential<Email> deserialized = objectMapper.readValue(serialized, typeRef);
 
         Email decryptedEmail = confidentialDataManager.decrypt(deserialized, Email::new);
@@ -71,20 +77,27 @@ public class ConfidentialTest {
     }
 
     @Test
-    void deserializationFailsOnInvalidMetadata() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
+    void deserializationFailsOnInvalidMetadata() throws InvalidAlgorithmParameterException, IllegalBlockSizeException,
+            NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException,
+            InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
         Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD, email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 
-        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {};
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {
+        };
         Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
         jsonData.put("metadata", Map.of("mode", Mode.AES_GCM_NOPAD.value));
 
         String tamperedValue = objectMapper.writeValueAsString(jsonData);
-        TypeReference<Confidential<Email>> confidentialEmailTypeRef = new TypeReference<>() {};
+        TypeReference<Confidential<Email>> confidentialEmailTypeRef = new TypeReference<>() {
+        };
 
-        assertThrows(ValueInstantiationException.class, () -> objectMapper.readValue(tamperedValue, confidentialEmailTypeRef));
+        assertThrows(
+                ValueInstantiationException.class,
+                () -> objectMapper.readValue(tamperedValue, confidentialEmailTypeRef)
+        );
     }
 }

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import it.pagopa.ecommerce.commons.domain.v1.Email;
 import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
+import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager.Mode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -43,7 +44,7 @@ public class ConfidentialTest {
     void confidentialJsonRepresentationIsOK() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
-        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(new AESMetadata(), email);
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD, email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 
@@ -57,7 +58,7 @@ public class ConfidentialTest {
     void roundtripEncryptionDecryptionIsSuccessful() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
-        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(new AESMetadata(), email);
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD, email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 
@@ -73,7 +74,7 @@ public class ConfidentialTest {
     void deserializationFailsOnInvalidMetadata() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
-        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(new AESMetadata(), email);
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD, email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
@@ -89,7 +89,7 @@ public class ConfidentialTest {
         TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {
         };
         Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
-        jsonData.put("metadata", Map.of("mode", Mode.AES_GCM_NOPAD.value));
+        jsonData.put("metadata", Map.of("mode", Mode.AES_GCM_NOPAD));
 
         String tamperedValue = objectMapper.writeValueAsString(jsonData);
         TypeReference<Confidential<Email>> confidentialEmailTypeRef = new TypeReference<>() {

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @ExtendWith(MockitoExtension.class)
 public class ConfidentialTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final ConfidentialMetadata confidentialMetadata = new AESMetadata();
     private final ConfidentialDataManager confidentialDataManager;
 
     ConfidentialTest() {
@@ -44,7 +43,7 @@ public class ConfidentialTest {
     void confidentialJsonRepresentationIsOK() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
-        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(confidentialMetadata, email);
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(new AESMetadata(), email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 
@@ -58,7 +57,7 @@ public class ConfidentialTest {
     void roundtripEncryptionDecryptionIsSuccessful() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
-        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(confidentialMetadata, email);
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(new AESMetadata(), email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 
@@ -74,7 +73,7 @@ public class ConfidentialTest {
     void deserializationFailsOnInvalidMetadata() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
-        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(confidentialMetadata, email);
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(new AESMetadata(), email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
@@ -1,0 +1,90 @@
+package it.pagopa.ecommerce.commons.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import it.pagopa.ecommerce.commons.domain.v1.Email;
+import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class ConfidentialTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ConfidentialMetadata confidentialMetadata = new AESMetadata();
+    private final ConfidentialDataManager confidentialDataManager;
+
+    ConfidentialTest() {
+        byte[] key = new byte[16];
+        new Random().nextBytes(key);
+
+        SecretKeySpec secretKey = new SecretKeySpec(key, "AES");
+        this.confidentialDataManager = new ConfidentialDataManager(secretKey);
+    }
+
+    @Test
+    void confidentialJsonRepresentationIsOK() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
+        Email email = new Email("foo@example.com");
+
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(confidentialMetadata, email);
+
+        String serialized = objectMapper.writeValueAsString(confidentialEmail);
+
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {};
+        Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
+
+        assertEquals(Set.of("data", "metadata"), jsonData.keySet());
+    }
+
+    @Test
+    void roundtripEncryptionDecryptionIsSuccessful() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
+        Email email = new Email("foo@example.com");
+
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(confidentialMetadata, email);
+
+        String serialized = objectMapper.writeValueAsString(confidentialEmail);
+
+        TypeReference<Confidential<Email>> typeRef = new TypeReference<>() {};
+        Confidential<Email> deserialized = objectMapper.readValue(serialized, typeRef);
+
+        Email decryptedEmail = confidentialDataManager.decrypt(deserialized, Email::new);
+
+        assertEquals(email, decryptedEmail);
+    }
+
+    @Test
+    void deserializationFailsOnInvalidMetadata() throws InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
+        Email email = new Email("foo@example.com");
+
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(confidentialMetadata, email);
+
+        String serialized = objectMapper.writeValueAsString(confidentialEmail);
+
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {};
+        Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
+        jsonData.put("metadata", "{}");
+
+        String tamperedValue = objectMapper.writeValueAsString(jsonData);
+        TypeReference<Confidential<Email>> confidentialEmailTypeRef = new TypeReference<>() {};
+
+        assertThrows(InvalidTypeIdException.class, () -> objectMapper.readValue(tamperedValue, confidentialEmailTypeRef));
+    }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

* add `Confidential<T>` class to handle sensitive data

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This PR adds the `Confidential<T>` data type that can be used to handle sensitive data that should be encrypted or protected in some way.

Currently the only mechanism implemented here is encryption via AES in GCM mode with a 12 byte long IV, a 16 byte long salt and no padding.

This is achieved through collaboration of different classes:
 * a class implementing the protection mechanism, currently only `AESCipher` is available
 * a metadata record used for serializing metadata related to the algorithm used by the implenting class (currently only `AESMetadata` is available)
 * a `Mode` enumeration value used to identify the protection mechanism (currently only  `AES_GCM_NOPAD` is available)
 * the class `ConfidentialDataManager` used to tie the implementing class, the mode and the metadata together, providing a uniform interface over those used to produce `Confidential<T>` instances

Note that `Confidential<T>` is just a serializable record and has no logic by itself on how to access protected data.
Same for instances of `ConfidentialMetadata` such as `AESMetadata`.

`Confidential<T>` is serialized as follows:
```json
{
    "data": "string" // protected data, as produced by the mehcanism specified by the mode in `ConfidentialMetadata`
    "metadata": {
        // fields in `ConfidentialMetadata` instance
    }
}
```

In the caes of `AESCipher`, `data` is a base64 encoded AES string, `metadata` contains `iv` and `salt` fields, both base64 encoded arrays of bytes.

Note that project-wise, this AES mechanism is meant to be temporary and will be replaced by an integration with the upcoming Personal Data Vault

**NOTE:**
Key rotation is not strictly implemented here. If necessary, a new `Mode` could be implemented for each new key.
Given that the AES approach is temporary no futher ergonomic adaptations are deemed necessary.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.