### PR TITLE
fix: add Nodo outcome to TransactionClosedEvent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,30 +273,6 @@
                             </configOptions>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>nodo-rest-api-v2</id>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <configuration>
-                            <inputSpec>
-                                https://raw.githubusercontent.com/pagopa/pagopa-infra/2d3db67b9638dc53ff2c04b1fc4fd2bc0f54763e/src/core/api/nodopagamenti_api/nodoPerPM/v2/_swagger.json.tpl
-                            </inputSpec>
-                            <generatorName>java</generatorName>
-                            <library>webclient</library>
-                            <generateApiDocumentation>false</generateApiDocumentation>
-                            <generateApiTests>false</generateApiTests>
-                            <generateModelTests>false</generateModelTests>
-                            <generateSupportingFiles>true</generateSupportingFiles>
-                            <configOptions>
-                                <swaggerAnnotations>false</swaggerAnnotations>
-                                <openApiNullable>false</openApiNullable>
-                            </configOptions>
-                            <modelPackage>it.pagopa.generated.ecommerce.nodo.v2.dto</modelPackage>
-                            <apiPackage>it.pagopa.generated.ecommerce.nodo.v2.api</apiPackage>
-                            <modelNameSuffix>dto</modelNameSuffix>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -401,7 +377,9 @@
                     <additionalOptions>
                         <additionalOption>--enable-preview</additionalOption>
                     </additionalOptions>
-                    <excludePackageNames>org.openapitools.*:it.pagopa.generated.*:it.pagopa.ecommerce.commons.generated.*</excludePackageNames>
+                    <excludePackageNames>
+                        org.openapitools.*:it.pagopa.generated.*:it.pagopa.ecommerce.commons.generated.*
+                    </excludePackageNames>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosedData.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosedData.java
@@ -1,0 +1,20 @@
+package it.pagopa.ecommerce.commons.documents.v1;
+
+import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * Data related to Nodo close payment outcome (OK/KO)
+ */
+@AllArgsConstructor
+@Data
+@Document
+public class TransactionClosedData {
+
+    /**
+     * The Nodo close payment outcome
+     */
+    private ClosePaymentResponseDto.OutcomeEnum outcome;
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosedEvent.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosedEvent.java
@@ -12,18 +12,18 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "eventstore")
 @NoArgsConstructor
 @ToString(callSuper = true)
-public final class TransactionClosedEvent extends TransactionEvent<TransactionClosedData> {
+public final class TransactionClosedEvent extends TransactionEvent<TransactionClosureData> {
 
     /**
      * Convenience constructor which sets the creation date to now
      *
-     * @param transactionId         transaction unique id
-     * @param transactionClosedData the transaction closed data
+     * @param transactionId          transaction unique id
+     * @param transactionClosureData the transaction closure operation data
      */
     public TransactionClosedEvent(
             String transactionId,
-            TransactionClosedData transactionClosedData
+            TransactionClosureData transactionClosureData
     ) {
-        super(transactionId, TransactionEventCode.TRANSACTION_CLOSED_EVENT, transactionClosedData);
+        super(transactionId, TransactionEventCode.TRANSACTION_CLOSED_EVENT, transactionClosureData);
     }
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosedEvent.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosedEvent.java
@@ -12,16 +12,18 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "eventstore")
 @NoArgsConstructor
 @ToString(callSuper = true)
-public final class TransactionClosedEvent extends TransactionEvent<Void> {
+public final class TransactionClosedEvent extends TransactionEvent<TransactionClosedData> {
 
     /**
      * Convenience constructor which sets the creation date to now
      *
-     * @param transactionId transaction unique id
+     * @param transactionId         transaction unique id
+     * @param transactionClosedData the transaction closed data
      */
     public TransactionClosedEvent(
-            String transactionId
+            String transactionId,
+            TransactionClosedData transactionClosedData
     ) {
-        super(transactionId, TransactionEventCode.TRANSACTION_CLOSED_EVENT, null);
+        super(transactionId, TransactionEventCode.TRANSACTION_CLOSED_EVENT, transactionClosedData);
     }
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosureData.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosureData.java
@@ -4,17 +4,19 @@ import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.lang.Nullable;
 
 /**
- * Data related to Nodo close payment outcome (OK/KO)
+ * Data related to Nodo close payment operation such as outcome (OK/KO)
  */
 @AllArgsConstructor
 @Data
 @Document
-public class TransactionClosedData {
+public class TransactionClosureData {
 
     /**
      * The Nodo close payment outcome
      */
+    @Nullable
     private ClosePaymentResponseDto.OutcomeEnum outcome;
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosureData.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosureData.java
@@ -3,7 +3,8 @@ package it.pagopa.ecommerce.commons.documents.v1;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * Data related to Nodo close payment operation such as outcome (OK/KO)
@@ -16,7 +17,7 @@ public class TransactionClosureData {
     /**
      * The Nodo closePayment outcome
      */
-    @Nullable
+    @NotNull
     private Outcome outcome;
 
     /**

--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosureData.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosureData.java
@@ -1,6 +1,5 @@
 package it.pagopa.ecommerce.commons.documents.v1;
 
-import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -15,8 +14,22 @@ import org.springframework.lang.Nullable;
 public class TransactionClosureData {
 
     /**
-     * The Nodo close payment outcome
+     * The Nodo closePayment outcome
      */
     @Nullable
-    private ClosePaymentResponseDto.OutcomeEnum outcome;
+    private Outcome outcome;
+
+    /**
+     * Enumeration of Nodo closePayment outcome
+     */
+    public enum Outcome {
+        /**
+         * closePayment OK outcome
+         */
+        OK,
+        /**
+         * closePayment KO outcome
+         */
+        KO
+    }
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosureData.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosureData.java
@@ -18,7 +18,7 @@ public class TransactionClosureData {
      * The Nodo closePayment outcome
      */
     @NotNull
-    private Outcome outcome;
+    private Outcome responseOutcome;
 
     /**
      * Enumeration of Nodo closePayment outcome

--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosureFailedEvent.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionClosureFailedEvent.java
@@ -12,16 +12,18 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "eventstore")
 @NoArgsConstructor
 @ToString(callSuper = true)
-public final class TransactionClosureFailedEvent extends TransactionEvent<Void> {
+public final class TransactionClosureFailedEvent extends TransactionEvent<TransactionClosureData> {
 
     /**
      * Convenience constructor which sets the creation date to now
      *
-     * @param transactionId transaction unique id
+     * @param transactionId          transaction unique id
+     * @param transactionClosureData the transaction closure operation data
      */
     public TransactionClosureFailedEvent(
-            String transactionId
+            String transactionId,
+            TransactionClosureData transactionClosureData
     ) {
-        super(transactionId, TransactionEventCode.TRANSACTION_CLOSURE_FAILED_EVENT, null);
+        super(transactionId, TransactionEventCode.TRANSACTION_CLOSURE_FAILED_EVENT, transactionClosureData);
     }
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionClosed.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionClosed.java
@@ -50,7 +50,7 @@ public final class TransactionClosed extends BaseTransactionWithCompletedAuthori
     public Transaction applyEvent(Object event) {
         return switch (event) {
             case TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent -> {
-                if (TransactionClosureData.Outcome.OK.equals(this.transactionClosedEvent.getData().getOutcome())) {
+                if (TransactionClosureData.Outcome.OK.equals(this.transactionClosedEvent.getData().getResponseOutcome())) {
                     yield new TransactionWithUserReceipt(this, transactionUserReceiptAddedEvent);
                 } else {
                     yield this;

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionClosed.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionClosed.java
@@ -1,9 +1,6 @@
 package it.pagopa.ecommerce.commons.domain.v1;
 
-import it.pagopa.ecommerce.commons.documents.v1.TransactionClosedEvent;
-import it.pagopa.ecommerce.commons.documents.v1.TransactionExpiredEvent;
-import it.pagopa.ecommerce.commons.documents.v1.TransactionRefundedEvent;
-import it.pagopa.ecommerce.commons.documents.v1.TransactionUserReceiptAddedEvent;
+import it.pagopa.ecommerce.commons.documents.v1.*;
 import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransactionWithCompletedAuthorization;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import lombok.AccessLevel;
@@ -52,8 +49,13 @@ public final class TransactionClosed extends BaseTransactionWithCompletedAuthori
     @Override
     public Transaction applyEvent(Object event) {
         return switch (event) {
-            case TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent ->
-                    new TransactionWithUserReceipt(this, transactionUserReceiptAddedEvent);
+            case TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent -> {
+                if (TransactionClosureData.Outcome.OK.equals(this.transactionClosedEvent.getData().getOutcome())) {
+                    yield new TransactionWithUserReceipt(this, transactionUserReceiptAddedEvent);
+                } else {
+                    yield this;
+                }
+            }
             case TransactionExpiredEvent transactionExpiredEvent ->
                     new TransactionExpired(this, transactionExpiredEvent);
             case TransactionRefundedEvent transactionRefundedEvent ->

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
@@ -5,7 +5,6 @@ import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransaction;
 import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
-import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -223,7 +222,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
 
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,
@@ -266,7 +265,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent authorizedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
 
         TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent = TransactionTestUtils
                 .transactionUserReceiptAddedEvent();
@@ -317,7 +316,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
 
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,
@@ -359,7 +358,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent authorizedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
 
         TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent = TransactionTestUtils
                 .transactionUserReceiptAddedEvent();
@@ -486,7 +485,7 @@ class TransactionTest {
                 .transactionAuthorizationCompletedEvent();
         TransactionClosureErrorEvent transactionClosureErrorEvent = TransactionTestUtils.transactionClosureErrorEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
 
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,
@@ -643,7 +642,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
         TransactionExpiredEvent expiredEvent = TransactionTestUtils
                 .transactionExpiredEvent(TransactionStatusDto.ACTIVATED);
 
@@ -696,7 +695,7 @@ class TransactionTest {
         TransactionExpiredEvent expiredEvent = TransactionTestUtils
                 .transactionExpiredEvent(TransactionStatusDto.ACTIVATED);
         TransactionClosedEvent closedEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,
                 authorizationRequestedEvent,
@@ -868,7 +867,7 @@ class TransactionTest {
         TransactionClosed transactionClosed = TransactionTestUtils
                 .transactionClosed(
                         transactionWithCompletedAuthorization,
-                        TransactionTestUtils.transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK)
+                        TransactionTestUtils.transactionClosedEvent(TransactionClosureData.Outcome.OK)
                 );
 
         assertEquals(TransactionStatusDto.CLOSED, transactionClosed.getStatus());
@@ -895,7 +894,7 @@ class TransactionTest {
         TransactionClosed transactionClosed = TransactionTestUtils
                 .transactionClosed(
                         transactionAuthorizationCompleted,
-                        TransactionTestUtils.transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK)
+                        TransactionTestUtils.transactionClosedEvent(TransactionClosureData.Outcome.OK)
                 );
 
         TransactionWithUserReceipt transactionWithUserReceipt = TransactionTestUtils
@@ -1018,7 +1017,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
         TransactionRefundedEvent transactionRefundedEvent = TransactionTestUtils
                 .transactionRefundedEvent(TransactionStatusDto.CLOSED);
 
@@ -1068,7 +1067,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
         TransactionRefundedEvent transactionRefundedEvent = TransactionTestUtils
                 .transactionRefundedEvent(TransactionStatusDto.CLOSED);
 
@@ -1218,7 +1217,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
         TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils
                 .transactionExpiredEvent(TransactionStatusDto.CLOSED);
 
@@ -1265,7 +1264,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
         TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils
                 .transactionExpiredEvent(TransactionStatusDto.CLOSED);
 
@@ -1581,7 +1580,7 @@ class TransactionTest {
 
         TransactionActivatedEvent transactionActivatedEvent = TransactionTestUtils.transactionActivateEvent();
         TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils
@@ -1644,7 +1643,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
-                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
+                .transactionClosedEvent(TransactionClosureData.Outcome.OK);
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,
                 transactionAuthorizationCompletedEvent,

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
@@ -1675,7 +1675,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosureFailedEvent transactionClosureFailedEvent = TransactionTestUtils
-                .transactionClosureFailedEvent();
+                .transactionClosureFailedEvent(TransactionClosureData.Outcome.OK);
 
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,
@@ -1718,7 +1718,7 @@ class TransactionTest {
         TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils
                 .transactionExpiredEvent(TransactionStatusDto.UNAUTHORIZED);
         TransactionClosureFailedEvent transactionClosureFailedEvent = TransactionTestUtils
-                .transactionClosureFailedEvent();
+                .transactionClosureFailedEvent(TransactionClosureData.Outcome.OK);
 
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
@@ -5,6 +5,7 @@ import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransaction;
 import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
+import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -222,7 +223,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent();
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
 
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,
@@ -265,7 +266,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent authorizedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent();
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
 
         TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent = TransactionTestUtils
                 .transactionUserReceiptAddedEvent();
@@ -316,7 +317,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent();
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
 
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,
@@ -358,7 +359,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent authorizedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent();
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
 
         TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent = TransactionTestUtils
                 .transactionUserReceiptAddedEvent();
@@ -485,7 +486,7 @@ class TransactionTest {
                 .transactionAuthorizationCompletedEvent();
         TransactionClosureErrorEvent transactionClosureErrorEvent = TransactionTestUtils.transactionClosureErrorEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent();
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
 
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,
@@ -642,7 +643,7 @@ class TransactionTest {
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionClosedEvent closureSentEvent = TransactionTestUtils
-                .transactionClosedEvent();
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
         TransactionExpiredEvent expiredEvent = TransactionTestUtils
                 .transactionExpiredEvent(TransactionStatusDto.ACTIVATED);
 
@@ -694,7 +695,8 @@ class TransactionTest {
                 .transactionAuthorizationCompletedEvent();
         TransactionExpiredEvent expiredEvent = TransactionTestUtils
                 .transactionExpiredEvent(TransactionStatusDto.ACTIVATED);
-        TransactionClosedEvent closedEvent = TransactionTestUtils.transactionClosedEvent();
+        TransactionClosedEvent closedEvent = TransactionTestUtils
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,
                 authorizationRequestedEvent,
@@ -866,7 +868,7 @@ class TransactionTest {
         TransactionClosed transactionClosed = TransactionTestUtils
                 .transactionClosed(
                         transactionWithCompletedAuthorization,
-                        TransactionTestUtils.transactionClosedEvent()
+                        TransactionTestUtils.transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK)
                 );
 
         assertEquals(TransactionStatusDto.CLOSED, transactionClosed.getStatus());
@@ -893,7 +895,7 @@ class TransactionTest {
         TransactionClosed transactionClosed = TransactionTestUtils
                 .transactionClosed(
                         transactionAuthorizationCompleted,
-                        TransactionTestUtils.transactionClosedEvent()
+                        TransactionTestUtils.transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK)
                 );
 
         TransactionWithUserReceipt transactionWithUserReceipt = TransactionTestUtils
@@ -1015,7 +1017,8 @@ class TransactionTest {
                 .transactionAuthorizationRequestedEvent();
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
-        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils.transactionClosedEvent();
+        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
         TransactionRefundedEvent transactionRefundedEvent = TransactionTestUtils
                 .transactionRefundedEvent(TransactionStatusDto.CLOSED);
 
@@ -1064,7 +1067,8 @@ class TransactionTest {
                 .transactionAuthorizationRequestedEvent();
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
-        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils.transactionClosedEvent();
+        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
         TransactionRefundedEvent transactionRefundedEvent = TransactionTestUtils
                 .transactionRefundedEvent(TransactionStatusDto.CLOSED);
 
@@ -1213,7 +1217,8 @@ class TransactionTest {
                 .transactionAuthorizationRequestedEvent();
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
-        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils.transactionClosedEvent();
+        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
         TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils
                 .transactionExpiredEvent(TransactionStatusDto.CLOSED);
 
@@ -1259,7 +1264,8 @@ class TransactionTest {
                 .transactionAuthorizationRequestedEvent();
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
-        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils.transactionClosedEvent();
+        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
         TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils
                 .transactionExpiredEvent(TransactionStatusDto.CLOSED);
 
@@ -1574,7 +1580,8 @@ class TransactionTest {
         EmptyTransaction transaction = new EmptyTransaction();
 
         TransactionActivatedEvent transactionActivatedEvent = TransactionTestUtils.transactionActivateEvent();
-        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils.transactionClosedEvent();
+        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
         TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils
@@ -1636,7 +1643,8 @@ class TransactionTest {
         TransactionUserCanceledEvent transactionUserCanceledEvent = TransactionTestUtils.transactionUserCanceledEvent();
         TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent = TransactionTestUtils
                 .transactionAuthorizationCompletedEvent();
-        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils.transactionClosedEvent();
+        TransactionClosedEvent transactionClosedEvent = TransactionTestUtils
+                .transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum.OK);
         Flux<Object> events = Flux.just(
                 transactionActivatedEvent,
                 transactionAuthorizationCompletedEvent,

--- a/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
@@ -148,7 +148,7 @@ public class TransactionTestUtils {
     public static TransactionClosedEvent transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum outcome) {
         return new TransactionClosedEvent(
                 TRANSACTION_ID,
-                new TransactionClosedData(outcome)
+                new TransactionClosureData(outcome)
         );
     }
 
@@ -218,9 +218,9 @@ public class TransactionTestUtils {
     @Nonnull
     public static TransactionUnauthorized transactionUnauthorized(
                                                                   BaseTransactionWithCompletedAuthorization transaction,
-                                                                  TransactionClosureFailedEvent transactionClosureFailedEven
+                                                                  TransactionClosureFailedEvent transactionClosureFailedEvent
     ) {
-        return new TransactionUnauthorized(transaction, transactionClosureFailedEven);
+        return new TransactionUnauthorized(transaction, transactionClosureFailedEvent);
     }
 
     @Nonnull
@@ -257,7 +257,8 @@ public class TransactionTestUtils {
     @Nonnull
     public static TransactionClosureFailedEvent transactionClosureFailedEvent() {
         return new TransactionClosureFailedEvent(
-                TRANSACTION_ID
+                TRANSACTION_ID,
+                new TransactionClosureData(null)
         );
     }
 

--- a/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
@@ -7,6 +7,7 @@ import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransaction;
 import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransactionWithCompletedAuthorization;
 import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
+import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
 
 import javax.annotation.Nonnull;
 import java.time.ZonedDateTime;
@@ -144,9 +145,10 @@ public class TransactionTestUtils {
     }
 
     @Nonnull
-    public static TransactionClosedEvent transactionClosedEvent() {
+    public static TransactionClosedEvent transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum outcome) {
         return new TransactionClosedEvent(
-                TRANSACTION_ID
+                TRANSACTION_ID,
+                new TransactionClosedData(outcome)
         );
     }
 

--- a/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
@@ -7,7 +7,6 @@ import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransaction;
 import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransactionWithCompletedAuthorization;
 import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
-import it.pagopa.generated.ecommerce.nodo.v2.dto.ClosePaymentResponseDto;
 
 import javax.annotation.Nonnull;
 import java.time.ZonedDateTime;
@@ -145,10 +144,18 @@ public class TransactionTestUtils {
     }
 
     @Nonnull
-    public static TransactionClosedEvent transactionClosedEvent(ClosePaymentResponseDto.OutcomeEnum outcome) {
+    public static TransactionClosedEvent transactionClosedEvent(TransactionClosureData.Outcome outcome) {
         return new TransactionClosedEvent(
                 TRANSACTION_ID,
                 new TransactionClosureData(outcome)
+        );
+    }
+
+    @Nonnull
+    public static TransactionClosedEvent transactionClosedEvent() {
+        return new TransactionClosedEvent(
+                TRANSACTION_ID,
+                new TransactionClosureData(TransactionClosureData.Outcome.OK)
         );
     }
 

--- a/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
@@ -152,14 +152,6 @@ public class TransactionTestUtils {
     }
 
     @Nonnull
-    public static TransactionClosedEvent transactionClosedEvent() {
-        return new TransactionClosedEvent(
-                TRANSACTION_ID,
-                new TransactionClosureData(TransactionClosureData.Outcome.OK)
-        );
-    }
-
-    @Nonnull
     public static TransactionClosureErrorEvent transactionClosureErrorEvent() {
         return new TransactionClosureErrorEvent(
                 TRANSACTION_ID
@@ -262,10 +254,10 @@ public class TransactionTestUtils {
     }
 
     @Nonnull
-    public static TransactionClosureFailedEvent transactionClosureFailedEvent() {
+    public static TransactionClosureFailedEvent transactionClosureFailedEvent(TransactionClosureData.Outcome outcome) {
         return new TransactionClosureFailedEvent(
                 TRANSACTION_ID,
-                new TransactionClosureData(null)
+                new TransactionClosureData(outcome)
         );
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add Nodo close payment outcome to TransactionClosedEvent
<!--- Describe your changes in detail -->

#### Motivation and Context
This additional information are needed in order to save the nodo close payment response outcome on the event store so that it can be retrieved from the eventstore
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.