### PR TITLE
[CHK-912] feat(confidential): add new mode for AES cipher with no salt and deterministic IV

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
@@ -71,6 +71,7 @@ public record AESMetadata(
      * YOU ARE DOING.
      * </p>
      *
+     * @param iv the initialization vector
      * @return a {@link AESMetadata} instance initialized with an IV only.
      */
     public static AESMetadata withoutSalt(@Nonnull IvParameterSpec iv) {

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
@@ -53,7 +53,8 @@ public record AESMetadata(
     @JsonTypeId
     @Override
     public ConfidentialDataManager.Mode getMode() {
-        return salt.isPresent() ? ConfidentialDataManager.Mode.AES_GCM_NOPAD : ConfidentialDataManager.Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV;
+        return salt.isPresent() ? ConfidentialDataManager.Mode.AES_GCM_NOPAD
+                : ConfidentialDataManager.Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV;
     }
 
     /**

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/AESMetadata.java
@@ -53,7 +53,7 @@ public record AESMetadata(
     @JsonTypeId
     @Override
     public ConfidentialDataManager.Mode getMode() {
-        return salt.isPresent() ? ConfidentialDataManager.Mode.AES_GCM_NOPAD : ConfidentialDataManager.Mode.AES_GCM_NOPAD_NOSALT;
+        return salt.isPresent() ? ConfidentialDataManager.Mode.AES_GCM_NOPAD : ConfidentialDataManager.Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV;
     }
 
     /**
@@ -72,8 +72,8 @@ public record AESMetadata(
      *
      * @return a {@link AESMetadata} instance initialized with an IV only.
      */
-    public static AESMetadata withoutSalt() {
-        return new AESMetadata(Optional.empty(), generateIv());
+    public static AESMetadata withoutSalt(@Nonnull IvParameterSpec iv) {
+        return new AESMetadata(Optional.empty(), iv);
     }
 
     @Override

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 @JsonSubTypes(
     {
             @JsonSubTypes.Type(value = AESMetadata.class, name = "AES_GCM_NOPAD"),
-            @JsonSubTypes.Type(value = AESMetadata.class, name = "AES_GCM_NOPAD_NOSALT"),
+            @JsonSubTypes.Type(value = AESMetadata.class, name = "AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV"),
     }
 )
 public sealed interface ConfidentialMetadata permits AESMetadata {

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/ConfidentialMetadata.java
@@ -18,6 +18,7 @@ import javax.annotation.Nonnull;
 @JsonSubTypes(
     {
             @JsonSubTypes.Type(value = AESMetadata.class, name = "AES_GCM_NOPAD"),
+            @JsonSubTypes.Type(value = AESMetadata.class, name = "AES_GCM_NOPAD_NOSALT"),
     }
 )
 public sealed interface ConfidentialMetadata permits AESMetadata {

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
@@ -49,12 +49,13 @@ public class ConfidentialDataManager {
         /**
          * <p>
          * This mode implements encryption with an AES cipher in GCM mode without
-         * padding, without salting and with a deterministic IV derived from the plaintext data.
+         * padding, without salting and with a deterministic IV derived from the
+         * plaintext data.
          * </p>
          * <p>
          * <b>NOTA BENE:</b> No salting has security implications which must be
-         * considered carefully. Not using a nonce for an IV has EVEN WIDER security implications.
-         * If you're unsure, use {@code AES_GCM_NOPAD}
+         * considered carefully. Not using a nonce for an IV has EVEN WIDER security
+         * implications. If you're unsure, use {@code AES_GCM_NOPAD}
          * </p>
          * For more details, see {@link AESCipher}.
          *

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/ConfidentialDataManager.java
@@ -1,5 +1,6 @@
 package it.pagopa.ecommerce.commons.utils;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import it.pagopa.ecommerce.commons.domain.AESMetadata;
 import it.pagopa.ecommerce.commons.domain.Confidential;
 import it.pagopa.ecommerce.commons.domain.ConfidentialMetadata;
@@ -40,7 +41,21 @@ public class ConfidentialDataManager {
          * This mode implements encryption with an AES cipher in GCM mode without
          * padding. For more details, see {@link AESCipher}.
          */
-        AES_GCM_NOPAD("AES/GCM/NoPadding");
+        AES_GCM_NOPAD("AES/GCM/NoPadding"),
+
+        /**
+         * <p>
+         * This mode implements encryption with an AES cipher in GCM mode without
+         * padding and without salting.
+         * </p>
+         * <p>
+         * <b>NOTA BENE:</b> No salting has security implications which must be
+         * considered carefully. If you're unsure, use {@code AES_GCM_NOPAD}
+         * </p>
+         * For more details, see {@link AESCipher}.
+         *
+         */
+        AES_GCM_NOPAD_NOSALT("AES/GCM/NoPadding");
 
         /**
          * String representation of the mode. Must be unique for each mode.
@@ -120,6 +135,13 @@ public class ConfidentialDataManager {
                     confidentialMetadata,
                     encryptData(confidentialMetadata, data.toStringRepresentation())
             );
+        } else if (mode == Mode.AES_GCM_NOPAD_NOSALT) {
+            AESMetadata confidentialMetadata = AESMetadata.withoutSalt();
+            return new Confidential<T>(
+                    confidentialMetadata,
+                    encryptData(confidentialMetadata, data.toStringRepresentation())
+            );
+
         } else {
             throw new IllegalArgumentException();
         }

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/AESMetadataTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/AESMetadataTest.java
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.crypto.spec.IvParameterSpec;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -18,6 +20,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith(MockitoExtension.class)
 public class AESMetadataTest {
     private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
+
+    private static final IvParameterSpec iv;
+
+    static {
+        byte[] ivData = new byte[AESMetadata.IV_LENGTH];
+        new Random().nextBytes(ivData);
+
+        iv = new IvParameterSpec(ivData);
+    }
 
     @Test
     void aesMetadataSerializationWithSaltIsOk() throws JsonProcessingException {
@@ -33,7 +44,7 @@ public class AESMetadataTest {
 
     @Test
     void aesMetadataSerializationWithoutSaltIsOk() throws JsonProcessingException {
-        AESMetadata metadata = AESMetadata.withoutSalt();
+        AESMetadata metadata = AESMetadata.withoutSalt(iv);
 
         String serialized = objectMapper.writeValueAsString(metadata);
         TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {
@@ -60,7 +71,7 @@ public class AESMetadataTest {
 
     @Test
     void aesSerializationRoundtripWithoutSaltIsSuccessful() throws JsonProcessingException {
-        AESMetadata metadata = AESMetadata.withoutSalt();
+        AESMetadata metadata = AESMetadata.withoutSalt(iv);
 
         String serialized = objectMapper.writeValueAsString(metadata);
 

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import it.pagopa.ecommerce.commons.domain.v1.Email;
 import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager;
 import it.pagopa.ecommerce.commons.utils.ConfidentialDataManager.Mode;
@@ -28,8 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
-class ConfidentialTest {
-    private final ObjectMapper objectMapper = new ObjectMapper();
+public class ConfidentialTest {
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
     private final ConfidentialDataManager confidentialDataManager;
 
     ConfidentialTest() {
@@ -41,7 +42,8 @@ class ConfidentialTest {
     }
 
     @Test
-    void confidentialJsonRepresentationIsOK() throws InvalidAlgorithmParameterException, IllegalBlockSizeException,
+    void confidentialJsonRepresentationWithSaltIsOK()
+            throws InvalidAlgorithmParameterException, IllegalBlockSizeException,
             NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException,
             InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
@@ -55,10 +57,11 @@ class ConfidentialTest {
         Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
 
         assertEquals(Set.of("data", "metadata"), jsonData.keySet());
+        assertEquals(((Map<String, Object>) jsonData.get("metadata")).get("mode"), Mode.AES_GCM_NOPAD.toString());
     }
 
     @Test
-    void roundtripEncryptionDecryptionIsSuccessful() throws InvalidAlgorithmParameterException,
+    void roundtripEncryptionDecryptionWithSaltIsSuccessful() throws InvalidAlgorithmParameterException,
             IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException,
             InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
@@ -77,18 +80,58 @@ class ConfidentialTest {
     }
 
     @Test
-    void deserializationFailsOnInvalidMetadata() throws InvalidAlgorithmParameterException, IllegalBlockSizeException,
+    void confidentialJsonRepresentationWithoutSaltIsOK()
+            throws InvalidAlgorithmParameterException, IllegalBlockSizeException,
             NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException,
             InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
-        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD, email);
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD_NOSALT, email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 
         TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {
         };
         Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
+
+        assertEquals(((Map<String, Object>) jsonData.get("metadata")).get("mode"), Mode.AES_GCM_NOPAD_NOSALT.toString());
+        assertEquals(Set.of("data", "metadata"), jsonData.keySet());
+    }
+
+    @Test
+    void roundtripEncryptionDecryptionWithoutSaltIsSuccessful() throws InvalidAlgorithmParameterException,
+            IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException,
+            InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
+        Email email = new Email("foo@example.com");
+
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD_NOSALT, email);
+
+        String serialized = objectMapper.writeValueAsString(confidentialEmail);
+
+        TypeReference<Confidential<Email>> typeRef = new TypeReference<>() {
+        };
+        Confidential<Email> deserialized = objectMapper.readValue(serialized, typeRef);
+
+        Email decryptedEmail = confidentialDataManager.decrypt(deserialized, Email::new);
+
+        assertEquals(Mode.AES_GCM_NOPAD_NOSALT, deserialized.confidentialMetadata().getMode());
+        assertEquals(email, decryptedEmail);
+    }
+
+    @Test
+    void deserializationFailsOnInvalidMetadata() throws InvalidAlgorithmParameterException, IllegalBlockSizeException,
+            NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeySpecException,
+            InvalidKeyException, JsonProcessingException {
+        Email email = new Email("foo@example.com");
+
+        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD_NOSALT, email);
+
+        String serialized = objectMapper.writeValueAsString(confidentialEmail);
+
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {
+        };
+        Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
+
         jsonData.put("metadata", Map.of("mode", Mode.AES_GCM_NOPAD));
 
         String tamperedValue = objectMapper.writeValueAsString(jsonData);

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/ConfidentialTest.java
@@ -68,7 +68,6 @@ public class ConfidentialTest {
         Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD, email);
         Confidential<Email> otherConfidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD, email);
 
-
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
         String otherSerialized = objectMapper.writeValueAsString(otherConfidentialEmail);
 
@@ -101,7 +100,8 @@ public class ConfidentialTest {
             InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
-        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV, email);
+        Confidential<Email> confidentialEmail = this.confidentialDataManager
+                .encrypt(Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV, email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 
@@ -109,17 +109,22 @@ public class ConfidentialTest {
         };
         Map<String, Object> jsonData = objectMapper.readValue(serialized, typeRef);
 
-        assertEquals(((Map<String, Object>) jsonData.get("metadata")).get("mode"), Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV.toString());
+        assertEquals(
+                ((Map<String, Object>) jsonData.get("metadata")).get("mode"),
+                Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV.toString()
+        );
         assertEquals(Set.of("data", "metadata"), jsonData.keySet());
     }
 
     @Test
-    void roundtripEncryptionDecryptionWithoutSaltWithDeterministicIvIsSuccessful() throws InvalidAlgorithmParameterException,
+    void roundtripEncryptionDecryptionWithoutSaltWithDeterministicIvIsSuccessful()
+            throws InvalidAlgorithmParameterException,
             IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException,
             InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
-        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV, email);
+        Confidential<Email> confidentialEmail = this.confidentialDataManager
+                .encrypt(Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV, email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 
@@ -139,9 +144,10 @@ public class ConfidentialTest {
             InvalidKeySpecException, InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
-        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV, email);
-        Confidential<Email> otherConfidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV, email);
-
+        Confidential<Email> confidentialEmail = this.confidentialDataManager
+                .encrypt(Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV, email);
+        Confidential<Email> otherConfidentialEmail = this.confidentialDataManager
+                .encrypt(Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV, email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
         String otherSerialized = objectMapper.writeValueAsString(otherConfidentialEmail);
@@ -155,7 +161,8 @@ public class ConfidentialTest {
             InvalidKeyException, JsonProcessingException {
         Email email = new Email("foo@example.com");
 
-        Confidential<Email> confidentialEmail = this.confidentialDataManager.encrypt(Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV, email);
+        Confidential<Email> confidentialEmail = this.confidentialDataManager
+                .encrypt(Mode.AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV, email);
 
         String serialized = objectMapper.writeValueAsString(confidentialEmail);
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

* allow AES cipher to optionally not use salt
* add new `ConfidentialDataManager.Mode` with deterministic IV and no salt

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR builds on top of #34 to support specific use-cases were salting would be detrimental (e.g. search by encrypted email address).
The implementation introduces a new protection `Mode` called `AES_GCM_NOPAD_NOSALT_DETERMINISTIC_IV`. As the name implies, this mode doesn't use salting and computes a deterministic IV instead of a cryptographically secure nonce.
This is done in order to have the same ciphertext given the same plaintext, in the case of email addresses this would directly allow search without decryption.
The deterministic IV currently is computed as the first 12 bytes of the SHA-1 hash of the plaintext data.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Local unit tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Depends on #34 