### PR TITLE
[CHK-1393] feat: add warmup controller logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,44 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <!--
+                There are two compilation executions:
+                the first one compiles the annotation processor alone excluding all annotations processors
+                from the compilation phase, the second one compiles all other classes.
+                This double compilation execution is needed because otherwise compilation will fail
+                during annotation processor scanning because of a missing WarmupAnnotationProcessor compiled
+                class.
+                The annotation processors are compiled in the execution with id `default-compile` so that
+                it's execute the first.
+                The other project classes are compiled in the execution with id `compile-project`
+                -->
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <source>17</source>
+                            <target>17</target>
+                            <compilerArgs>-proc:none</compilerArgs>
+                            <includes>
+                                <include>
+                                    it/pagopa/ecommerce/commons/utils/warmup/annotationprocessor/WarmupAnnotationProcessor.java
+                                </include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-project</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>17</source>
+                            <target>17</target>
+                            <compilerArgs>--enable-preview</compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
                     <source>17</source>
                     <target>17</target>
@@ -279,7 +317,8 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>https://api.uat.tokenizer.pdv.pagopa.it/docs/tokenizeruapis/openapi.json</inputSpec>
+                            <inputSpec>https://api.uat.tokenizer.pdv.pagopa.it/docs/tokenizeruapis/openapi.json
+                            </inputSpec>
                             <generatorName>java</generatorName>
                             <library>webclient</library>
                             <generateApiDocumentation>false</generateApiDocumentation>

--- a/src/main/java/it/pagopa/ecommerce/commons/annotations/Warmup.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/annotations/Warmup.java
@@ -11,6 +11,6 @@ import java.lang.annotation.*;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface WarmupMethod {
+public @interface Warmup {
 
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/annotations/WarmupMethod.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/annotations/WarmupMethod.java
@@ -1,0 +1,16 @@
+package it.pagopa.ecommerce.commons.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation used to annotate a controller method to be called during module
+ * warm-up phase. Warm-up function can be used to send request to a
+ * RestController in order to initialize all it's resource before the module
+ * being ready to serve requests
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface WarmupMethod {
+
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/warmup/ControllerWarmup.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/warmup/ControllerWarmup.java
@@ -1,0 +1,76 @@
+package it.pagopa.ecommerce.commons.utils.warmup;
+
+import it.pagopa.ecommerce.commons.annotations.WarmupMethod;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Controller warmup logic. This class is an {@link ApplicationListener} for the
+ * {@link ContextRefreshedEvent} raised when an ApplicationContext gets
+ * initialized or refreshed. Once the event is fired the classpath is scanned
+ * searching for all {@link RestController} an, for each of those, searching for
+ * methods annotated with {@link WarmupMethod} to be executed
+ *
+ * @see WarmupMethod
+ * @see ContextRefreshedEvent
+ * @see ApplicationListener
+ */
+@Component
+@Slf4j
+public class ControllerWarmup implements ApplicationListener<ContextRefreshedEvent> {
+
+    /**
+     * Callback method that handles {@link ContextRefreshedEvent} event
+     *
+     * @param event the event to respond to
+     */
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        event
+                .getApplicationContext()
+                .getBeansWithAnnotation(RestController.class)
+                .values()
+                .forEach(this::warmupController);
+    }
+
+    private void warmupController(Object controller) {
+        Class<?> controllerClass = ClassUtils.getUserClass(controller.getClass());
+        AtomicInteger warmUpMethods = new AtomicInteger();
+        long startTime = System.currentTimeMillis();
+        Arrays.stream(controllerClass.getDeclaredMethods())
+                .filter(method -> method.isAnnotationPresent(WarmupMethod.class))
+                .forEach(method -> {
+                    long methodStartTime = System.currentTimeMillis();
+                    warmUpMethods.incrementAndGet();
+                    try {
+                        log.info("Invoking method: [{}]", method);
+                        method.invoke(controller);
+                    } catch (InvocationTargetException | IllegalAccessException e) {
+                        log.error("Exception invoking warmup method", e);
+                    } finally {
+                        long interTime = System.currentTimeMillis() - methodStartTime;
+                        log.info(
+                                "Warmup method: [{}] -> elapsed time: [{}] ms",
+                                method,
+                                interTime
+                        );
+                    }
+
+                });
+        long elapsedTime = System.currentTimeMillis() - startTime;
+        log.info(
+                "Controller: [{}] warm-up executed methods: [{}], elapsed time: [{}] ms",
+                controllerClass,
+                warmUpMethods,
+                elapsedTime
+        );
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/warmup/annotationprocessor/WarmupAnnotationProcessor.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/warmup/annotationprocessor/WarmupAnnotationProcessor.java
@@ -1,0 +1,92 @@
+package it.pagopa.ecommerce.commons.utils.warmup.annotationprocessor;
+
+import it.pagopa.ecommerce.commons.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.element.*;
+import javax.tools.Diagnostic;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * {@link Warmup} annotation processor. This annotation processor checks that
+ * the {@link Warmup} annotated method has no arguments and that its declaring
+ * class is annotated with {@link RestController}
+ */
+@SupportedAnnotationTypes("it.pagopa.ecommerce.commons.annotations.Warmup")
+public class WarmupAnnotationProcessor extends AbstractProcessor {
+
+    private final Logger logger = LoggerFactory.getLogger(WarmupAnnotationProcessor.class);
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        logger.info("WarmupAnnotationProcessor initialized");
+    }
+
+    /**
+     * Process all annotated methods
+     *
+     * @param annotations the annotation interfaces requested to be processed
+     * @param roundEnv    environment for information about the current and prior
+     *                    round
+     * @return true for letting other annotations processor scanning other elements
+     */
+    @Override
+    public boolean process(
+                           Set<? extends TypeElement> annotations,
+                           RoundEnvironment roundEnv
+    ) {
+        logger.info("WarmupAnnotationProcessor start process");
+
+        for (Element element : roundEnv.getElementsAnnotatedWith(Warmup.class)) {
+
+            if (element instanceof ExecutableElement executableElement) {
+                Element declaringClass = executableElement.getEnclosingElement();
+                Set<Modifier> modifiers = executableElement.getModifiers();
+                String className = declaringClass.toString();
+                String warmupMethod = executableElement.getSimpleName().toString();
+                List<? extends VariableElement> parameters = executableElement.getParameters();
+
+                if (!parameters.isEmpty()) {
+                    processingEnv.getMessager()
+                            .printMessage(
+                                    Diagnostic.Kind.ERROR,
+                                    "Warmup method: [%s.%s] should not have arguments"
+                                            .formatted(className, warmupMethod)
+                            );
+                }
+                if (modifiers.size() != 1 || !modifiers.contains(Modifier.PUBLIC)) {
+                    processingEnv.getMessager()
+                            .printMessage(
+                                    Diagnostic.Kind.ERROR,
+                                    "Warmup method: [%s.%s] should have only public modifier"
+                                            .formatted(className, warmupMethod)
+                            );
+                }
+                if (declaringClass.getAnnotation(RestController.class) == null) {
+                    processingEnv.getMessager().printMessage(
+                            Diagnostic.Kind.ERROR,
+                            "Found warmup method in class [%s] but is not annotated with @RestController"
+                                    .formatted(className)
+                    );
+                }
+            } else {
+                processingEnv.getMessager().printMessage(
+                        Diagnostic.Kind.ERROR,
+                        "Invalid annotation location, annotation expected on method but found on: [%s]"
+                                .formatted(element.getKind())
+                );
+            }
+
+        }
+        return true; // no further processing of this annotation type
+    }
+
+}

--- a/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+it.pagopa.ecommerce.commons.utils.warmup.annotationprocessor.WarmupAnnotationProcessor

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/warmup/ControllerWarmupTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/warmup/ControllerWarmupTest.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
-import static com.mongodb.internal.connection.tlschannel.util.Util.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class ControllerWarmupTest {

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/warmup/ControllerWarmupTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/warmup/ControllerWarmupTest.java
@@ -93,7 +93,7 @@ class ControllerWarmupTest {
          * performed against the onApplicationEvent method duration that should be
          * comparable with a single warmup method duration
          */
-        assertTrue(elapsedTime / 1000 == 1);
+        assertTrue(elapsedTime < 3000);
 
     }
 

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/warmup/ControllerWarmupTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/warmup/ControllerWarmupTest.java
@@ -149,6 +149,7 @@ class ControllerWarmupTest {
         boolean warmUp();
     }
 
+    @RestController
     private class MockedRestControllerWithWarmupMethods {
 
         @Warmup

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/warmup/ControllerWarmupTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/warmup/ControllerWarmupTest.java
@@ -1,0 +1,150 @@
+package it.pagopa.ecommerce.commons.utils.warmup;
+
+import it.pagopa.ecommerce.commons.annotations.WarmupMethod;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+class ControllerWarmupTest {
+
+    private final ControllerWarmup controllerWarmup = new ControllerWarmup();
+
+    @Mock
+    private ContextRefreshedEvent contextRefreshedEvent;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    private final Sentinel sentinel = new Sentinel() {
+        @Override
+        public void warmUp() {
+
+        }
+    };
+    private final Sentinel warmupSentinel = Mockito.spy(sentinel);
+
+    private final Sentinel otherMethodSentinel = Mockito.spy(sentinel);
+
+    private final MockedRestControllerWithWarmupMethods mockRestController = new MockedRestControllerWithWarmupMethods();
+
+    private final MockedRestControllerWithoutWarmupMethods mockRestControllerWithoutWarmup = new MockedRestControllerWithoutWarmupMethods();
+
+    @Test
+    void shouldCallWarmupMethods() {
+        /*
+         * pre-conditions
+         */
+        Mockito.when(contextRefreshedEvent.getApplicationContext()).thenReturn(applicationContext);
+        Mockito.when(applicationContext.getBeansWithAnnotation(RestController.class))
+                .thenReturn(Map.of("mockRestController", mockRestController));
+
+        /*
+         * Test
+         */
+        controllerWarmup.onApplicationEvent(contextRefreshedEvent);
+        /*
+         * Assertions
+         */
+        Mockito.verify(contextRefreshedEvent, Mockito.times(1)).getApplicationContext();
+        Mockito.verify(applicationContext, Mockito.times(1)).getBeansWithAnnotation(RestController.class);
+        Mockito.verify(warmupSentinel, Mockito.times(2)).warmUp();
+        Mockito.verify(otherMethodSentinel, Mockito.times(0)).warmUp();
+
+    }
+
+    @Test
+    void shouldHandleWarmupMethodsException() {
+        /*
+         * pre-conditions
+         */
+        Mockito.when(contextRefreshedEvent.getApplicationContext()).thenReturn(applicationContext);
+        Mockito.when(applicationContext.getBeansWithAnnotation(RestController.class))
+                .thenReturn(Map.of("mockRestController", mockRestController));
+        Mockito.doThrow(new RuntimeException("Exception invoking warmup method")).when(warmupSentinel).warmUp();
+        /*
+         * Test
+         */
+        Assertions.assertDoesNotThrow(() -> controllerWarmup.onApplicationEvent(contextRefreshedEvent));
+
+        /*
+         * Assertions
+         */
+        Mockito.verify(contextRefreshedEvent, Mockito.times(1)).getApplicationContext();
+        Mockito.verify(applicationContext, Mockito.times(1)).getBeansWithAnnotation(RestController.class);
+        Mockito.verify(warmupSentinel, Mockito.times(2)).warmUp();
+        Mockito.verify(otherMethodSentinel, Mockito.times(0)).warmUp();
+
+    }
+
+    @Test
+    void shouldIgnoreControllersWithoutWarmupMethods() {
+        /*
+         * pre-conditions
+         */
+        Mockito.when(contextRefreshedEvent.getApplicationContext()).thenReturn(applicationContext);
+        Mockito.when(applicationContext.getBeansWithAnnotation(RestController.class))
+                .thenReturn(Map.of("mockRestController", mockRestControllerWithoutWarmup));
+        /*
+         * Test
+         */
+        controllerWarmup.onApplicationEvent(contextRefreshedEvent);
+
+        /*
+         * Assertions
+         */
+        Mockito.verify(contextRefreshedEvent, Mockito.times(1)).getApplicationContext();
+        Mockito.verify(applicationContext, Mockito.times(1)).getBeansWithAnnotation(RestController.class);
+        Mockito.verify(warmupSentinel, Mockito.times(0)).warmUp();
+        Mockito.verify(otherMethodSentinel, Mockito.times(0)).warmUp();
+
+    }
+
+    private interface Sentinel {
+        void warmUp();
+    }
+
+    private class MockedRestControllerWithWarmupMethods {
+
+        @WarmupMethod
+        public void warmupMethod() {
+            warmupSentinel.warmUp();
+
+        }
+
+        @WarmupMethod
+        public void otherWarmupMethod() {
+            warmupSentinel.warmUp();
+
+        }
+
+        public void noWarmupMethod() {
+            otherMethodSentinel.warmUp();
+
+        }
+    }
+
+    private class MockedRestControllerWithoutWarmupMethods {
+
+        public void noWarmupMethod() {
+            /*
+             * put system out here to verify that sentinel object .toString() method is
+             * invoked by warmup logic
+             */
+            callWarmupMethod(otherMethodSentinel);
+
+        }
+
+        private void callWarmupMethod(Sentinel sentinel) {
+            sentinel.warmUp();
+        }
+    }
+}

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/warmup/annotationprocessor/WarmupAnnotationProcessorTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/warmup/annotationprocessor/WarmupAnnotationProcessorTest.java
@@ -1,0 +1,327 @@
+package it.pagopa.ecommerce.commons.utils.warmup.annotationprocessor;
+
+import it.pagopa.ecommerce.commons.annotations.Warmup;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.*;
+import javax.tools.Diagnostic;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class WarmupAnnotationProcessorTest {
+
+    private final ProcessingEnvironment processingEnv = Mockito.mock(ProcessingEnvironment.class);
+
+    private final RoundEnvironment roundEnv = Mockito.mock(RoundEnvironment.class);
+
+    private final Element element = Mockito.mock(Element.class);
+
+    private final ExecutableElement executableElement = Mockito.mock(ExecutableElement.class);
+
+    private final VariableElement variableElement = Mockito.mock(VariableElement.class);
+
+    private final Element warmupMethodEnclosingElement = Mockito.mock(Element.class);
+
+    private final Name executableElementName = Mockito.mock(Name.class);
+
+    private final Messager messager = Mockito.mock(Messager.class);
+
+    private final WarmupAnnotationProcessor warmupAnnotationProcessor = new WarmupAnnotationProcessor();
+
+    private final RestController restControllerAnnotation = Mockito.mock(RestController.class);
+
+    @Test
+    void shouldRaiseErrorForWarmupMethodWithArgParameters() {
+        /*
+         * pre-requisite
+         */
+        Mockito.when(processingEnv.getMessager()).thenReturn(messager);
+        Mockito.when(roundEnv.getElementsAnnotatedWith(Warmup.class)).thenReturn((Set) Set.of(executableElement));
+        Mockito.when(executableElement.getEnclosingElement()).thenReturn(warmupMethodEnclosingElement);
+        Mockito.when(executableElement.getSimpleName()).thenReturn(executableElementName);
+        Mockito.when(executableElementName.toString()).thenReturn("executableElementName");
+        Mockito.when(executableElement.getParameters()).thenReturn((List) List.of(variableElement));
+        Mockito.when(executableElement.getModifiers()).thenReturn(Set.of(Modifier.PUBLIC));
+        Mockito.when(warmupMethodEnclosingElement.getAnnotation(RestController.class))
+                .thenReturn(restControllerAnnotation);
+        /*
+         * Test
+         */
+        warmupAnnotationProcessor.init(processingEnv);
+        warmupAnnotationProcessor.process(Collections.emptySet(), roundEnv);
+
+        /*
+         * Assertions
+         */
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                argThat(
+                        message -> message.equals(
+                                "Warmup method: [warmupMethodEnclosingElement.executableElementName] should not have arguments"
+                        )
+                )
+        );
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                any()
+        );
+    }
+
+    @Test
+    void shouldRaiseErrorForWarmupMethodInClassThatHasNotRestControllerAnnotation() {
+        /*
+         * pre-requisite
+         */
+        Mockito.when(processingEnv.getMessager()).thenReturn(messager);
+        Mockito.when(roundEnv.getElementsAnnotatedWith(Warmup.class)).thenReturn((Set) Set.of(executableElement));
+        Mockito.when(executableElement.getEnclosingElement()).thenReturn(warmupMethodEnclosingElement);
+        Mockito.when(executableElement.getSimpleName()).thenReturn(executableElementName);
+        Mockito.when(executableElementName.toString()).thenReturn("executableElementName");
+        Mockito.when(executableElement.getParameters()).thenReturn(List.of());
+        Mockito.when(executableElement.getModifiers()).thenReturn(Set.of(Modifier.PUBLIC));
+        Mockito.when(warmupMethodEnclosingElement.getAnnotation(RestController.class)).thenReturn(null);
+        /*
+         * Test
+         */
+        warmupAnnotationProcessor.init(processingEnv);
+        boolean returnValue = warmupAnnotationProcessor.process(Collections.emptySet(), roundEnv);
+
+        /*
+         * Assertions
+         */
+        assertTrue(returnValue);
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                argThat(
+                        message -> message.equals(
+                                "Found warmup method in class [warmupMethodEnclosingElement] but is not annotated with @RestController"
+                        )
+                )
+        );
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                any()
+        );
+    }
+
+    @Test
+    void shouldRaiseErrorForWarmupMethodWithInvalidVisibility() {
+        /*
+         * pre-requisite
+         */
+        Mockito.when(processingEnv.getMessager()).thenReturn(messager);
+        Mockito.when(roundEnv.getElementsAnnotatedWith(Warmup.class)).thenReturn((Set) Set.of(executableElement));
+        Mockito.when(executableElement.getEnclosingElement()).thenReturn(warmupMethodEnclosingElement);
+        Mockito.when(executableElement.getSimpleName()).thenReturn(executableElementName);
+        Mockito.when(executableElementName.toString()).thenReturn("executableElementName");
+        Mockito.when(executableElement.getParameters()).thenReturn(List.of());
+        Mockito.when(executableElement.getModifiers()).thenReturn(Set.of(Modifier.PRIVATE));
+        Mockito.when(warmupMethodEnclosingElement.getAnnotation(RestController.class))
+                .thenReturn(restControllerAnnotation);
+        /*
+         * Test
+         */
+        warmupAnnotationProcessor.init(processingEnv);
+        boolean returnValue = warmupAnnotationProcessor.process(Collections.emptySet(), roundEnv);
+
+        /*
+         * Assertions
+         */
+        assertTrue(returnValue);
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                argThat(
+                        message -> message.equals(
+                                "Warmup method: [warmupMethodEnclosingElement.executableElementName] should have only public modifier"
+                        )
+                )
+        );
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                any()
+        );
+    }
+
+    @Test
+    void shouldRaiseErrorForWarmupMethodWithInvalidModifiers() {
+        /*
+         * pre-requisite
+         */
+        Mockito.when(processingEnv.getMessager()).thenReturn(messager);
+        Mockito.when(roundEnv.getElementsAnnotatedWith(Warmup.class)).thenReturn((Set) Set.of(executableElement));
+        Mockito.when(executableElement.getEnclosingElement()).thenReturn(warmupMethodEnclosingElement);
+        Mockito.when(executableElement.getSimpleName()).thenReturn(executableElementName);
+        Mockito.when(executableElementName.toString()).thenReturn("executableElementName");
+        Mockito.when(executableElement.getParameters()).thenReturn(List.of());
+        Mockito.when(executableElement.getModifiers()).thenReturn(Set.of(Modifier.PRIVATE, Modifier.STATIC));
+        Mockito.when(warmupMethodEnclosingElement.getAnnotation(RestController.class))
+                .thenReturn(restControllerAnnotation);
+        /*
+         * Test
+         */
+        warmupAnnotationProcessor.init(processingEnv);
+        boolean returnValue = warmupAnnotationProcessor.process(Collections.emptySet(), roundEnv);
+
+        /*
+         * Assertions
+         */
+        assertTrue(returnValue);
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                argThat(
+                        message -> message.equals(
+                                "Warmup method: [warmupMethodEnclosingElement.executableElementName] should have only public modifier"
+                        )
+                )
+        );
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                any()
+        );
+    }
+
+    @Test
+    void shouldRaiseErrorForAnnotationAppliedOnInvalidElement() {
+        /*
+         * pre-requisite
+         */
+        Mockito.when(processingEnv.getMessager()).thenReturn(messager);
+        Mockito.when(roundEnv.getElementsAnnotatedWith(Warmup.class)).thenReturn((Set) Set.of(variableElement));
+        Mockito.when(variableElement.getKind()).thenReturn(ElementKind.FIELD);
+        Mockito.when(warmupMethodEnclosingElement.getAnnotation(RestController.class))
+                .thenReturn(restControllerAnnotation);
+        /*
+         * Test
+         */
+        warmupAnnotationProcessor.init(processingEnv);
+        boolean returnValue = warmupAnnotationProcessor.process(Collections.emptySet(), roundEnv);
+
+        /*
+         * Assertions
+         */
+        assertTrue(returnValue);
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                argThat(
+                        message -> message.equals(
+                                "Invalid annotation location, annotation expected on method but found on: [FIELD]"
+                        )
+                )
+        );
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                any()
+        );
+    }
+
+    @Test
+    void shouldRaiseAllValidationErrors() {
+        /*
+         * pre-requisite
+         */
+        Mockito.when(processingEnv.getMessager()).thenReturn(messager);
+        Mockito.when(roundEnv.getElementsAnnotatedWith(Warmup.class)).thenReturn((Set) Set.of(executableElement));
+        Mockito.when(executableElement.getEnclosingElement()).thenReturn(warmupMethodEnclosingElement);
+        Mockito.when(executableElement.getSimpleName()).thenReturn(executableElementName);
+        Mockito.when(executableElementName.toString()).thenReturn("executableElementName");
+        Mockito.when(executableElement.getParameters()).thenReturn((List) List.of(variableElement));
+        Mockito.when(executableElement.getModifiers()).thenReturn(Set.of(Modifier.PRIVATE));
+        Mockito.when(warmupMethodEnclosingElement.getAnnotation(RestController.class)).thenReturn(null);
+        /*
+         * Test
+         */
+        warmupAnnotationProcessor.init(processingEnv);
+        boolean returnValue = warmupAnnotationProcessor.process(Collections.emptySet(), roundEnv);
+
+        /*
+         * Assertions
+         */
+        assertTrue(returnValue);
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                argThat(
+                        message -> message.equals(
+                                "Found warmup method in class [warmupMethodEnclosingElement] but is not annotated with @RestController"
+                        )
+                )
+        );
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                argThat(
+                        message -> message.equals(
+                                "Warmup method: [warmupMethodEnclosingElement.executableElementName] should not have arguments"
+                        )
+                )
+        );
+        Mockito.verify(messager, Mockito.times(1)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                argThat(
+                        message -> message.equals(
+                                "Warmup method: [warmupMethodEnclosingElement.executableElementName] should have only public modifier"
+                        )
+                )
+        );
+        Mockito.verify(messager, Mockito.times(3)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                any()
+        );
+    }
+
+    @Test
+    void shouldNotRaiseErrorForMethodAnnotatedWithWarmupInRestControllerAnnotatedClassAndCorrectVisibility() {
+        /*
+         * pre-requisite
+         */
+        Mockito.when(processingEnv.getMessager()).thenReturn(messager);
+        Mockito.when(roundEnv.getElementsAnnotatedWith(Warmup.class)).thenReturn((Set) Set.of(executableElement));
+        Mockito.when(executableElement.getEnclosingElement()).thenReturn(warmupMethodEnclosingElement);
+        Mockito.when(executableElement.getSimpleName()).thenReturn(executableElementName);
+        Mockito.when(executableElementName.toString()).thenReturn("executableElementName");
+        Mockito.when(executableElement.getParameters()).thenReturn(List.of());
+        Mockito.when(executableElement.getModifiers()).thenReturn(Set.of(Modifier.PUBLIC));
+        Mockito.when(warmupMethodEnclosingElement.getAnnotation(RestController.class))
+                .thenReturn(restControllerAnnotation);
+        /*
+         * Test
+         */
+        warmupAnnotationProcessor.init(processingEnv);
+        boolean returnValue = warmupAnnotationProcessor.process(Collections.emptySet(), roundEnv);
+
+        /*
+         * Assertions
+         */
+        assertTrue(returnValue);
+        Mockito.verify(messager, Mockito.times(0)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                argThat(
+                        message -> message.equals(
+                                "Found warmup method in class [warmupMethodEnclosingElement] but is not annotated with @RestController"
+                        )
+                )
+        );
+        Mockito.verify(messager, Mockito.times(0)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                argThat(
+                        message -> message.equals(
+                                "Warmup method: [warmupMethodEnclosingElement.executableElementName] should not have arguments"
+                        )
+                )
+        );
+        Mockito.verify(messager, Mockito.times(0)).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                any()
+        );
+    }
+}


### PR DESCRIPTION
Depends on: https://github.com/pagopa/pagopa-ecommerce-commons/pull/72
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add generic Controller warmup logic.
The mail class is `ControllerWarmup` that listens for `ContextRefreshedEvent`, raised by Spring framework when ApplicationContext has been started.
Starting from this event, ApplicationContext is then scanned searching for all managed beans annotated with `RestController` annotation and, for each of those, scanning all methods annotated with @WarmupMethod custom annotation.
Those annotated methods are finally executed performing the specific implemented warmup logic and logging overall and each method elapsed time
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed in order to have a common logic to perform module-specific warmup logic (such as performing an HTTP request on a specific endpoint to let all resources being initialized before the module deploy.
This allow module to be ready and with all resources loaded before being deployed
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + local test using ecommerce commons and integrating this logic with transactions-service
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.