### PR TITLE
fix: transaction id must not be longer than 35 chars

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v1/Transaction.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v1/Transaction.java
@@ -125,7 +125,7 @@ public class Transaction {
      */
     public static Transaction from(TransactionActivated transaction) {
         return new Transaction(
-                transaction.getTransactionId().value().toString(),
+                transaction.getTransactionId().value().toString().replace("-", ""),
                 transaction.getTransactionActivatedData().getPaymentNotices(),
                 null,
                 transaction.getTransactionActivatedData().getEmail(),

--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionEvent.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionEvent.java
@@ -41,6 +41,17 @@ public abstract sealed class TransactionEvent<T> permits BaseTransactionClosureE
             String creationDate,
             T data
     ) {
+        /*
+         * CHK-1413 -> transaction id length lesser than 35 chars here is checked that
+         * transaction id is 32 chars long that is UUID with trimmed '-' chars length
+         */
+
+        if (transactionId == null || transactionId.length() != 32) {
+            throw new IllegalArgumentException(
+                    "Invalid input transaction id: [%s]. Transaction id must be length 32 chars (UUID with trimmed dash)"
+                            .formatted(transactionId)
+            );
+        }
         this.id = UUID.randomUUID().toString();
         this.transactionId = transactionId;
         this.eventCode = eventCode;
@@ -53,10 +64,6 @@ public abstract sealed class TransactionEvent<T> permits BaseTransactionClosureE
             TransactionEventCode eventCode,
             T data
     ) {
-        this.id = UUID.randomUUID().toString();
-        this.transactionId = transactionId;
-        this.eventCode = eventCode;
-        this.data = data;
-        this.creationDate = now().toString();
+        this(transactionId, eventCode, now().toString(), data);
     }
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v1/EmptyTransaction.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v1/EmptyTransaction.java
@@ -4,7 +4,6 @@ import it.pagopa.ecommerce.commons.documents.v1.TransactionActivatedEvent;
 import lombok.EqualsAndHashCode;
 
 import java.time.ZonedDateTime;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -23,7 +22,7 @@ import java.util.stream.Collectors;
 public final class EmptyTransaction implements Transaction {
     private TransactionActivated applyActivation(TransactionActivatedEvent event) {
         return new TransactionActivated(
-                new TransactionId(UUID.fromString(event.getTransactionId())),
+                new TransactionId(event.getTransactionId()),
                 event.getData().getPaymentNotices().stream()
                         .map(
                                 n -> new PaymentNotice(

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionId.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionId.java
@@ -27,16 +27,6 @@ public record TransactionId(UUID uuid) {
     }
 
     /**
-     * Get transaction id as {@link UUID} object
-     *
-     * @return the {@link UUID} transaction id representation
-     */
-    @Override
-    public UUID uuid() {
-        return uuid;
-    }
-
-    /**
      * Get transaction id string value
      *
      * @return transaction id as UUID string without dashes

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionId.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionId.java
@@ -14,6 +14,13 @@ import java.util.UUID;
 @ValueObject
 public record TransactionId(UUID value) {
 
+    /**
+     * Create transaction id object parsing input String value.
+     *
+     * @param value - the UUID string without `-` chars
+     * @throws IllegalArgumentException if input value is not a valid UUID string
+     *                                  without dashes
+     */
     public TransactionId(String value) {
         this(TransactionId.fromTrimmedUUIDString(value));
 

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionId.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionId.java
@@ -13,4 +13,31 @@ import java.util.UUID;
  */
 @ValueObject
 public record TransactionId(UUID value) {
+
+    public TransactionId(String value) {
+        this(TransactionId.fromTrimmedUUIDString(value));
+
+    }
+
+    private static UUID fromTrimmedUUIDString(String trimmedUUIDString) {
+        if (trimmedUUIDString == null || trimmedUUIDString.length() != 32) {
+            throw new IllegalArgumentException(
+                    "Invalid transaction id: [%s]. Transaction id must be not null and 32 chars length"
+                            .formatted(trimmedUUIDString)
+            );
+        }
+        char[] uuid = new char[36];
+        char[] trimmedUUID = trimmedUUIDString.toCharArray();
+        System.arraycopy(trimmedUUID, 0, uuid, 0, 8);
+        System.arraycopy(trimmedUUID, 8, uuid, 9, 4);
+        System.arraycopy(trimmedUUID, 12, uuid, 14, 4);
+        System.arraycopy(trimmedUUID, 16, uuid, 19, 4);
+        System.arraycopy(trimmedUUID, 20, uuid, 24, 12);
+        uuid[8] = '-';
+        uuid[13] = '-';
+        uuid[18] = '-';
+        uuid[23] = '-';
+        return UUID.fromString(new String(uuid));
+    }
+
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionId.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionId.java
@@ -9,10 +9,10 @@ import java.util.UUID;
  * Value object holding a transaction id.
  * </p>
  *
- * @param value the transaction id
+ * @param uuid the transaction id
  */
 @ValueObject
-public record TransactionId(UUID value) {
+public record TransactionId(UUID uuid) {
 
     /**
      * Create transaction id object parsing input String value.
@@ -24,6 +24,25 @@ public record TransactionId(UUID value) {
     public TransactionId(String value) {
         this(TransactionId.fromTrimmedUUIDString(value));
 
+    }
+
+    /**
+     * Get transaction id as {@link UUID} object
+     *
+     * @return the {@link UUID} transaction id representation
+     */
+    @Override
+    public UUID uuid() {
+        return uuid;
+    }
+
+    /**
+     * Get transaction id string value
+     *
+     * @return transaction id as UUID string without dashes
+     */
+    public String value() {
+        return uuid.toString().replace("-", "");
     }
 
     private static UUID fromTrimmedUUIDString(String trimmedUUIDString) {

--- a/src/test/java/it/pagopa/ecommerce/commons/documents/v1/TransactionDocumentTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/documents/v1/TransactionDocumentTest.java
@@ -35,6 +35,7 @@ class TransactionDocumentTest {
         assertEquals(TransactionTestUtils.RPT_ID, transaction.getPaymentNotices().get(0).getRptId());
         assertEquals(TransactionTestUtils.DESCRIPTION, transaction.getPaymentNotices().get(0).getDescription());
         assertEquals(TransactionTestUtils.AMOUNT, transaction.getPaymentNotices().get(0).getAmount());
+        assertEquals(TransactionTestUtils.TRANSACTION_ID, transaction.getTransactionId());
         assertEquals(transactionStatus, transaction.getStatus());
 
         assertNotEquals(transaction, differentTransaction);
@@ -76,4 +77,5 @@ class TransactionDocumentTest {
             assertEquals(Transaction.ClientId.fromString(clientId.toString()).toString(), clientId.toString());
         }
     }
+
 }

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionIdTests.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionIdTests.java
@@ -12,9 +12,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TransactionIdTests {
 
-
     @ParameterizedTest
-    @ValueSource(strings = {"", "transactionIdtransactionIdtransa"})
+    @ValueSource(
+            strings = {
+                    "",
+                    "transactionIdtransactionIdtransa"
+            }
+    )
     @NullSource
     void shouldFailCreateTransactionIdForInvalidInput(String transactionId) {
         assertThrows(IllegalArgumentException.class, () -> new TransactionId(transactionId));

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionIdTests.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionIdTests.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TransactionIdTests {
+class TransactionIdTests {
 
     @Test
     void shouldFailCreateTransactionIdFromTooShortString() {

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionIdTests.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionIdTests.java
@@ -1,0 +1,35 @@
+package it.pagopa.ecommerce.commons.domain.v1;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TransactionIdTests {
+
+    @Test
+    void shouldFailCreateTransactionIdFromTooShortString() {
+        assertThrows(IllegalArgumentException.class, () -> new TransactionId(""));
+    }
+
+    @Test
+    void shouldFailCreateTransactionIdFromInvalidUUIDString() {
+        assertThrows(IllegalArgumentException.class, () -> new TransactionId("transactionIdtransactionIdtransa"));
+    }
+
+    @Test
+    void shouldFailCreateTransactionIdFromNullUUIDString() {
+        assertThrows(IllegalArgumentException.class, () -> new TransactionId((String) null));
+    }
+
+    @Test
+    void shouldCreateTransactionIdSuccessfully() {
+        UUID uuid = UUID.randomUUID();
+        String trimmedUUID = uuid.toString().replace("-", "");
+        TransactionId transactionId = new TransactionId(trimmedUUID);
+        assertEquals(uuid, transactionId.uuid());
+        assertEquals(trimmedUUID, transactionId.value());
+    }
+}

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionIdTests.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionIdTests.java
@@ -1,6 +1,9 @@
 package it.pagopa.ecommerce.commons.domain.v1;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.UUID;
 
@@ -9,19 +12,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TransactionIdTests {
 
-    @Test
-    void shouldFailCreateTransactionIdFromTooShortString() {
-        assertThrows(IllegalArgumentException.class, () -> new TransactionId(""));
-    }
 
-    @Test
-    void shouldFailCreateTransactionIdFromInvalidUUIDString() {
-        assertThrows(IllegalArgumentException.class, () -> new TransactionId("transactionIdtransactionIdtransa"));
-    }
-
-    @Test
-    void shouldFailCreateTransactionIdFromNullUUIDString() {
-        assertThrows(IllegalArgumentException.class, () -> new TransactionId((String) null));
+    @ParameterizedTest
+    @ValueSource(strings = {"", "transactionIdtransactionIdtransa"})
+    @NullSource
+    void shouldFailCreateTransactionIdForInvalidInput(String transactionId) {
+        assertThrows(IllegalArgumentException.class, () -> new TransactionId(transactionId));
     }
 
     @Test

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
@@ -9,6 +9,9 @@ import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -4554,40 +4557,19 @@ class TransactionTest {
                 ).verifyComplete();
     }
 
-    @Test
-    void shouldFailReducingEventForInvalidTransactionIdTooShort() {
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                    "",
+                    "transactionIdtransactionIdtransa"
+            }
+    )
+    @NullSource
+    void shouldFailReducingEvent(String transactionId) {
 
         TransactionActivatedEvent transactionActivatedEvent = Mockito
                 .spy(TransactionTestUtils.transactionActivateEvent());
-        Mockito.when(transactionActivatedEvent.getTransactionId()).thenReturn("");
-
-        Mono<it.pagopa.ecommerce.commons.domain.v1.Transaction> reducedEvent = Flux.just(transactionActivatedEvent)
-                .reduce(new EmptyTransaction(), it.pagopa.ecommerce.commons.domain.v1.Transaction::applyEvent);
-        StepVerifier.create(reducedEvent)
-                .expectError(IllegalArgumentException.class)
-                .verify();
-
-    }
-
-    @Test
-    void shouldFailReducingEventForInvalidTransactionIdNotAValidUUID() {
-        TransactionActivatedEvent transactionActivatedEvent = Mockito
-                .spy(TransactionTestUtils.transactionActivateEvent());
-        Mockito.when(transactionActivatedEvent.getTransactionId()).thenReturn("transactionIdtransactionIdtransa");
-
-        Mono<it.pagopa.ecommerce.commons.domain.v1.Transaction> reducedEvent = Flux.just(transactionActivatedEvent)
-                .reduce(new EmptyTransaction(), it.pagopa.ecommerce.commons.domain.v1.Transaction::applyEvent);
-        StepVerifier.create(reducedEvent)
-                .expectError(IllegalArgumentException.class)
-                .verify();
-
-    }
-
-    @Test
-    void shouldFailReducingEventForInvalidTransactionIdNull() {
-        TransactionActivatedEvent transactionActivatedEvent = Mockito
-                .spy(TransactionTestUtils.transactionActivateEvent());
-        Mockito.when(transactionActivatedEvent.getTransactionId()).thenReturn(null);
+        Mockito.when(transactionActivatedEvent.getTransactionId()).thenReturn(transactionId);
 
         Mono<it.pagopa.ecommerce.commons.domain.v1.Transaction> reducedEvent = Flux.just(transactionActivatedEvent)
                 .reduce(new EmptyTransaction(), it.pagopa.ecommerce.commons.domain.v1.Transaction::applyEvent);

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
@@ -4611,8 +4611,9 @@ class TransactionTest {
         StepVerifier.create(reducedEvent)
                 .expectNextMatches(t -> {
                     TransactionActivated tx = (TransactionActivated) t;
-                    return tx.getTransactionId().value()
-                            .equals(transactionId);
+                    return tx.getTransactionId().uuid()
+                            .equals(transactionId)
+                            && tx.getTransactionId().value().equals(trimmedTransactionId);
                 })
                 .verifyComplete();
 

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
@@ -9,11 +9,13 @@ import it.pagopa.ecommerce.commons.generated.server.model.AuthorizationResultDto
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.ZonedDateTime;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -4550,6 +4552,60 @@ class TransactionTest {
                                             .equals(TransactionStatusDto.CLOSURE_ERROR);
                         }
                 ).verifyComplete();
+    }
+
+    @Test
+    void shouldFailReducingEventForInvalidTransactionIdTooShort() {
+
+        TransactionActivatedEvent transactionActivatedEvent = Mockito
+                .spy(TransactionTestUtils.transactionActivateEvent());
+        Mockito.when(transactionActivatedEvent.getTransactionId()).thenReturn("");
+
+        Mono<it.pagopa.ecommerce.commons.domain.v1.Transaction> reducedEvent = Flux.just(transactionActivatedEvent)
+                .reduce(new EmptyTransaction(), it.pagopa.ecommerce.commons.domain.v1.Transaction::applyEvent);
+        StepVerifier.create(reducedEvent)
+                .expectError(IllegalArgumentException.class)
+                .verify();
+
+    }
+
+    @Test
+    void shouldFailReducingEventForInvalidTransactionIdNotAValidUUID() {
+
+        TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
+                "transactionIdtransactionIdtransa",
+                ZonedDateTime.now().toString(),
+                TransactionTestUtils.transactionActivateEvent().getData()
+        );
+
+        Mono<it.pagopa.ecommerce.commons.domain.v1.Transaction> reducedEvent = Flux.just(transactionActivatedEvent)
+                .reduce(new EmptyTransaction(), it.pagopa.ecommerce.commons.domain.v1.Transaction::applyEvent);
+        StepVerifier.create(reducedEvent)
+                .expectError(IllegalArgumentException.class)
+                .verify();
+
+    }
+
+    @Test
+    void shouldConvertTransactionIdSuccessfully() {
+        UUID transactionId = UUID.randomUUID();
+        String trimmedTransactionId = transactionId.toString().replace("-", "");
+        TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
+                trimmedTransactionId,
+                ZonedDateTime.now().toString(),
+                TransactionTestUtils.transactionActivateEvent().getData()
+        );
+
+        Mono<it.pagopa.ecommerce.commons.domain.v1.Transaction> reducedEvent = Flux.just(transactionActivatedEvent)
+                .reduce(new EmptyTransaction(), it.pagopa.ecommerce.commons.domain.v1.Transaction::applyEvent);
+        StepVerifier.create(reducedEvent)
+                .expectNextMatches(t -> {
+                    TransactionActivated tx = (TransactionActivated) t;
+                    return tx.getTransactionId().value()
+                            .equals(transactionId);
+                })
+                .verifyComplete();
+
     }
 
 }

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v1/TransactionTest.java
@@ -4571,12 +4571,23 @@ class TransactionTest {
 
     @Test
     void shouldFailReducingEventForInvalidTransactionIdNotAValidUUID() {
+        TransactionActivatedEvent transactionActivatedEvent = Mockito
+                .spy(TransactionTestUtils.transactionActivateEvent());
+        Mockito.when(transactionActivatedEvent.getTransactionId()).thenReturn("transactionIdtransactionIdtransa");
 
-        TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
-                "transactionIdtransactionIdtransa",
-                ZonedDateTime.now().toString(),
-                TransactionTestUtils.transactionActivateEvent().getData()
-        );
+        Mono<it.pagopa.ecommerce.commons.domain.v1.Transaction> reducedEvent = Flux.just(transactionActivatedEvent)
+                .reduce(new EmptyTransaction(), it.pagopa.ecommerce.commons.domain.v1.Transaction::applyEvent);
+        StepVerifier.create(reducedEvent)
+                .expectError(IllegalArgumentException.class)
+                .verify();
+
+    }
+
+    @Test
+    void shouldFailReducingEventForInvalidTransactionIdNull() {
+        TransactionActivatedEvent transactionActivatedEvent = Mockito
+                .spy(TransactionTestUtils.transactionActivateEvent());
+        Mockito.when(transactionActivatedEvent.getTransactionId()).thenReturn(null);
 
         Mono<it.pagopa.ecommerce.commons.domain.v1.Transaction> reducedEvent = Flux.just(transactionActivatedEvent)
                 .reduce(new EmptyTransaction(), it.pagopa.ecommerce.commons.domain.v1.Transaction::applyEvent);
@@ -4590,11 +4601,10 @@ class TransactionTest {
     void shouldConvertTransactionIdSuccessfully() {
         UUID transactionId = UUID.randomUUID();
         String trimmedTransactionId = transactionId.toString().replace("-", "");
-        TransactionActivatedEvent transactionActivatedEvent = new TransactionActivatedEvent(
-                trimmedTransactionId,
-                ZonedDateTime.now().toString(),
-                TransactionTestUtils.transactionActivateEvent().getData()
-        );
+
+        TransactionActivatedEvent transactionActivatedEvent = Mockito
+                .spy(TransactionTestUtils.transactionActivateEvent());
+        Mockito.when(transactionActivatedEvent.getTransactionId()).thenReturn(trimmedTransactionId);
 
         Mono<it.pagopa.ecommerce.commons.domain.v1.Transaction> reducedEvent = Flux.just(transactionActivatedEvent)
                 .reduce(new EmptyTransaction(), it.pagopa.ecommerce.commons.domain.v1.Transaction::applyEvent);

--- a/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
@@ -51,7 +51,7 @@ public class TransactionTestUtils {
     public static final String AUTHORIZATION_REQUEST_ID = UUID.randomUUID().toString();
 
     public static final TransactionAuthorizationRequestData.PaymentGateway PAYMENT_GATEWAY = TransactionAuthorizationRequestData.PaymentGateway.VPOS;
-    public static final String TRANSACTION_ID = UUID.randomUUID().toString();
+    public static final String TRANSACTION_ID = UUID.randomUUID().toString().replace("-", "");
     public static final String TRANSFER_PA_FISCAL_CODE = "transferPAFiscalCode";
     public static final Boolean TRANSFER_DIGITAL_STAMP = true;
     public static final Integer TRANSFER_AMOUNT = 0;
@@ -108,7 +108,7 @@ public class TransactionTestUtils {
     @Nonnull
     public static TransactionActivated transactionActivated(String creationDate) {
         return new TransactionActivated(
-                new TransactionId(UUID.fromString(TRANSACTION_ID)),
+                new TransactionId(TRANSACTION_ID),
                 List.of(
                         new it.pagopa.ecommerce.commons.domain.v1.PaymentNotice(
                                 new PaymentToken(PAYMENT_TOKEN),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Modified transaction id to be shorter than 35 chars. This modification has been carried out trimming `-`characters from UUID string that produce a 32 chars string (36 UUID string format less 4 dashes)
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to generate a transaction id lesser that the Nodo expected 35 chars and use the same transaction id across the whole application
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Jnuit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.