### PR TITLE
fix: redis delete

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/redis/templatewrappers/RedisTemplateWrapper.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/redis/templatewrappers/RedisTemplateWrapper.java
@@ -59,8 +59,8 @@ abstract sealed class RedisTemplateWrapper<V> permits PaymentRequestInfoRedisTem
      * @param key - the entity key to be deleted
      * @return the deleted key
      */
-    public V deleteById(String key) {
-        return redisTemplate.opsForValue().getAndDelete(compoundKeyWithKeyspace(key));
+    public Boolean deleteById(String key) {
+        return redisTemplate.delete(compoundKeyWithKeyspace(key));
     }
 
     /**

--- a/src/test/java/it/pagopa/ecommerce/commons/redis/templatewrappers/PaymentRequestInfoRedisTemplateWrapperTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/redis/templatewrappers/PaymentRequestInfoRedisTemplateWrapperTest.java
@@ -75,16 +75,13 @@ class PaymentRequestInfoRedisTemplateWrapperTest {
     @Test
     void shouldDeleteEntitySuccessfully() {
         // assertions
-        PaymentRequestInfo expected = TransactionTestUtils.paymentRequestInfo();
-        Mockito.when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        Mockito.when(valueOperations.getAndDelete("keys:%s".formatted(TransactionTestUtils.RPT_ID)))
-                .thenReturn(expected);
+        Mockito.when(redisTemplate.delete("keys:%s".formatted(TransactionTestUtils.RPT_ID)))
+                .thenReturn(Boolean.TRUE);
         // test
-        PaymentRequestInfo actual = paymentRequestInfoRedisTemplateWrapper.deleteById(TransactionTestUtils.RPT_ID);
-
+        Boolean deleteResult = paymentRequestInfoRedisTemplateWrapper.deleteById(TransactionTestUtils.RPT_ID);
         // assertions
-        Mockito.verify(valueOperations, Mockito.times(1))
-                .getAndDelete("keys:%s".formatted(TransactionTestUtils.RPT_ID));
-        assertEquals(expected, actual);
+        Mockito.verify(redisTemplate, Mockito.times(1))
+                .delete("keys:%s".formatted(TransactionTestUtils.RPT_ID));
+        assertTrue(deleteResult);
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Change Redis delete method from GETDEL to DEL ones.
#### Motivation and Context
RedisTemplate OpsForVal expose GETDEL Redis method for get and delete a key. 
This method, by the way, is supported starting from Redis 6.2.0 and ecommerce Redis version is 6.0 so this method is not supported. 
DEL method, instead, is supported starting from Redis 1.0 version.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit test and local tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.