### PR TITLE
feat: add transaction activation date into cache

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/repositories/PaymentRequestInfo.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/repositories/PaymentRequestInfo.java
@@ -8,6 +8,7 @@ import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
+
 import java.util.List;
 
 /**
@@ -34,6 +35,7 @@ public record PaymentRequestInfo(
         @Nullable Integer amount,
         @Nullable String dueDate,
         @Nullable String paymentToken,
+        @Nullable String activationDate,
         @Nullable IdempotencyKey idempotencyKey,
         @Nullable List<PaymentTransferInfo> transferList
 ) {
@@ -49,6 +51,7 @@ public record PaymentRequestInfo(
      * @param amount         Amount on the payment notice
      * @param dueDate        Payment's due date
      * @param paymentToken   Payment token associated to this payment request
+     * @param activationDate Transaction activation date
      * @param idempotencyKey Idempotency key associated to the payment request
      * @param transferList   Payment transfer list information
      */

--- a/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
@@ -156,8 +156,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithRequestedAuthorization transactionWithRequestedAuthorization(
-            TransactionAuthorizationRequestedEvent authorizationRequestedEvent,
-            TransactionActivated transactionActivated
+                                                                                              TransactionAuthorizationRequestedEvent authorizationRequestedEvent,
+                                                                                              TransactionActivated transactionActivated
     ) {
         return new TransactionWithRequestedAuthorization(
                 transactionActivated,
@@ -189,7 +189,7 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionAuthorizationRequestedEvent transactionAuthorizationRequestedEvent(
-            TransactionAuthorizationRequestData.PaymentGateway paymentGateway
+                                                                                                TransactionAuthorizationRequestData.PaymentGateway paymentGateway
     ) {
         return new TransactionAuthorizationRequestedEvent(
                 TRANSACTION_ID,
@@ -227,7 +227,7 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent(
-            AuthorizationResultDto authorizationResultDto
+                                                                                                AuthorizationResultDto authorizationResultDto
     ) {
         return new TransactionAuthorizationCompletedEvent(
                 TRANSACTION_ID,
@@ -243,8 +243,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent(
-            AuthorizationResultDto authorizationResultDto,
-            String rnn
+                                                                                                AuthorizationResultDto authorizationResultDto,
+                                                                                                String rnn
     ) {
         return new TransactionAuthorizationCompletedEvent(
                 TRANSACTION_ID,
@@ -260,8 +260,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionAuthorizationCompleted transactionAuthorizationCompleted(
-            TransactionAuthorizationCompletedEvent authorizedEvent,
-            TransactionWithRequestedAuthorization transactionWithRequestedAuthorization
+                                                                                      TransactionAuthorizationCompletedEvent authorizedEvent,
+                                                                                      TransactionWithRequestedAuthorization transactionWithRequestedAuthorization
     ) {
         return new TransactionAuthorizationCompleted(
                 transactionWithRequestedAuthorization,
@@ -286,8 +286,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithClosureError transactionWithClosureError(
-            TransactionClosureErrorEvent transactionClosureErrorEvent,
-            BaseTransactionWithPaymentToken transaction
+                                                                          TransactionClosureErrorEvent transactionClosureErrorEvent,
+                                                                          BaseTransactionWithPaymentToken transaction
     ) {
         return new TransactionWithClosureError(
                 transaction,
@@ -297,8 +297,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionClosed transactionClosed(
-            BaseTransactionWithCompletedAuthorization transactionWithCompletedAuthorization,
-            TransactionClosedEvent transactionClosedEvent
+                                                      BaseTransactionWithCompletedAuthorization transactionWithCompletedAuthorization,
+                                                      TransactionClosedEvent transactionClosedEvent
     ) {
         return new TransactionClosed(
                 transactionWithCompletedAuthorization,
@@ -308,8 +308,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithUserReceiptOk transactionWithUserReceiptOk(
-            BaseTransactionWithRequestedUserReceipt baseTransaction,
-            TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent
+                                                                            BaseTransactionWithRequestedUserReceipt baseTransaction,
+                                                                            TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent
     ) {
         return new TransactionWithUserReceiptOk(
                 baseTransaction,
@@ -319,8 +319,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithUserReceiptKo transactionWithUserReceiptKo(
-            BaseTransactionWithRequestedUserReceipt baseTransaction,
-            TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent
+                                                                            BaseTransactionWithRequestedUserReceipt baseTransaction,
+                                                                            TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent
     ) {
         return new TransactionWithUserReceiptKo(
                 baseTransaction,
@@ -330,7 +330,7 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent(
-            TransactionUserReceiptData data
+                                                                                    TransactionUserReceiptData data
     ) {
         return new TransactionUserReceiptAddedEvent(
                 TRANSACTION_ID,
@@ -350,72 +350,72 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionExpired transactionExpired(
-            BaseTransactionWithRequestedAuthorization transaction,
-            TransactionExpiredEvent expiredEvent
+                                                        BaseTransactionWithRequestedAuthorization transaction,
+                                                        TransactionExpiredEvent expiredEvent
     ) {
         return new TransactionExpired(transaction, expiredEvent);
     }
 
     @Nonnull
     public static TransactionRefunded transactionRefunded(
-            BaseTransactionWithRefundRequested transaction,
-            TransactionRefundedEvent transactionRefundedEvent
+                                                          BaseTransactionWithRefundRequested transaction,
+                                                          TransactionRefundedEvent transactionRefundedEvent
     ) {
         return new TransactionRefunded(transaction, transactionRefundedEvent);
     }
 
     @Nonnull
     public static TransactionUnauthorized transactionUnauthorized(
-            BaseTransactionWithCompletedAuthorization transaction,
-            TransactionClosureFailedEvent transactionClosureFailedEvent
+                                                                  BaseTransactionWithCompletedAuthorization transaction,
+                                                                  TransactionClosureFailedEvent transactionClosureFailedEvent
     ) {
         return new TransactionUnauthorized(transaction, transactionClosureFailedEvent);
     }
 
     @Nonnull
     public static TransactionUserCanceled transactionUserCanceled(
-            BaseTransactionWithCancellationRequested transaction,
-            TransactionClosedEvent transactionClosedEvent
+                                                                  BaseTransactionWithCancellationRequested transaction,
+                                                                  TransactionClosedEvent transactionClosedEvent
     ) {
         return new TransactionUserCanceled(transaction, transactionClosedEvent);
     }
 
     @Nonnull
     public static TransactionWithCancellationRequested transactionWithCancellationRequested(
-            BaseTransactionWithPaymentToken baseTransaction,
-            TransactionUserCanceledEvent transactionUserCanceledEvent
+                                                                                            BaseTransactionWithPaymentToken baseTransaction,
+                                                                                            TransactionUserCanceledEvent transactionUserCanceledEvent
     ) {
         return new TransactionWithCancellationRequested(baseTransaction, transactionUserCanceledEvent);
     }
 
     @Nonnull
     public static TransactionCancellationExpired transactionCancellationExpired(
-            BaseTransactionWithCancellationRequested baseTransaction,
-            TransactionExpiredEvent transactionExpiredEvent
+                                                                                BaseTransactionWithCancellationRequested baseTransaction,
+                                                                                TransactionExpiredEvent transactionExpiredEvent
     ) {
         return new TransactionCancellationExpired(baseTransaction, transactionExpiredEvent);
     }
 
     @Nonnull
     public static TransactionExpiredNotAuthorized transactionExpiredNotAuthorized(
-            BaseTransaction transaction,
-            TransactionExpiredEvent transactionExpiredEvent
+                                                                                  BaseTransaction transaction,
+                                                                                  TransactionExpiredEvent transactionExpiredEvent
     ) {
         return new TransactionExpiredNotAuthorized(transaction, transactionExpiredEvent);
     }
 
     @Nonnull
     public static TransactionWithRefundError transactionWithRefundError(
-            BaseTransactionWithRefundRequested baseTransaction,
-            TransactionRefundErrorEvent transactionRefundErrorEvent
+                                                                        BaseTransactionWithRefundRequested baseTransaction,
+                                                                        TransactionRefundErrorEvent transactionRefundErrorEvent
     ) {
         return new TransactionWithRefundError(baseTransaction, transactionRefundErrorEvent);
     }
 
     @Nonnull
     public static TransactionWithRefundRequested transactionWithRefundRequested(
-            BaseTransactionWithRequestedAuthorization baseTransaction,
-            TransactionRefundRequestedEvent transactionRefundRequestedEvent
+                                                                                BaseTransactionWithRequestedAuthorization baseTransaction,
+                                                                                TransactionRefundRequestedEvent transactionRefundRequestedEvent
     ) {
         return new TransactionWithRefundRequested(
                 baseTransaction,
@@ -472,7 +472,7 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionRefundRequestedEvent transactionRefundRequestedEvent(
-            BaseTransaction baseTransaction
+                                                                                  BaseTransaction baseTransaction
     ) {
         return new TransactionRefundRequestedEvent(
                 TRANSACTION_ID,
@@ -490,7 +490,7 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionUserReceiptAddErrorEvent transactionUserReceiptAddErrorEvent(
-            TransactionUserReceiptData data
+                                                                                          TransactionUserReceiptData data
     ) {
         return new TransactionUserReceiptAddErrorEvent(
                 TRANSACTION_ID,
@@ -508,8 +508,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithUserReceiptError transactionWithUserReceiptError(
-            BaseTransactionWithRequestedUserReceipt baseTransaction,
-            TransactionUserReceiptAddErrorEvent transactionUserReceiptAddErrorEvent
+                                                                                  BaseTransactionWithRequestedUserReceipt baseTransaction,
+                                                                                  TransactionUserReceiptAddErrorEvent transactionUserReceiptAddErrorEvent
     ) {
         return new TransactionWithUserReceiptError(
                 baseTransaction,
@@ -519,8 +519,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static Transaction transactionDocument(
-            TransactionStatusDto transactionStatus,
-            ZonedDateTime creationDateTime
+                                                  TransactionStatusDto transactionStatus,
+                                                  ZonedDateTime creationDateTime
     ) {
         return new Transaction(
                 TRANSACTION_ID,
@@ -553,15 +553,15 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithRequestedUserReceipt transactionWithRequestedUserReceipt(
-            BaseTransactionClosed baseTransactionClosed,
-            TransactionUserReceiptRequestedEvent transactionUserReceiptRequestedEvent
+                                                                                          BaseTransactionClosed baseTransactionClosed,
+                                                                                          TransactionUserReceiptRequestedEvent transactionUserReceiptRequestedEvent
     ) {
         return new TransactionWithRequestedUserReceipt(baseTransactionClosed, transactionUserReceiptRequestedEvent);
     }
 
     @Nonnull
     public static TransactionUserReceiptRequestedEvent transactionUserReceiptRequestedEvent(
-            TransactionUserReceiptData transactionUserReceiptData
+                                                                                            TransactionUserReceiptData transactionUserReceiptData
     ) {
         return new TransactionUserReceiptRequestedEvent(
                 TRANSACTION_ID,
@@ -600,8 +600,8 @@ public class TransactionTestUtils {
                 .stream()
                 .reduce(
                         (
-                                trx,
-                                event
+                         trx,
+                         event
                         ) -> ((it.pagopa.ecommerce.commons.domain.v1.Transaction) trx).applyEvent(event)
                 )
                 .orElseThrow(

--- a/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/v1/TransactionTestUtils.java
@@ -156,8 +156,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithRequestedAuthorization transactionWithRequestedAuthorization(
-                                                                                              TransactionAuthorizationRequestedEvent authorizationRequestedEvent,
-                                                                                              TransactionActivated transactionActivated
+            TransactionAuthorizationRequestedEvent authorizationRequestedEvent,
+            TransactionActivated transactionActivated
     ) {
         return new TransactionWithRequestedAuthorization(
                 transactionActivated,
@@ -189,7 +189,7 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionAuthorizationRequestedEvent transactionAuthorizationRequestedEvent(
-                                                                                                TransactionAuthorizationRequestData.PaymentGateway paymentGateway
+            TransactionAuthorizationRequestData.PaymentGateway paymentGateway
     ) {
         return new TransactionAuthorizationRequestedEvent(
                 TRANSACTION_ID,
@@ -227,7 +227,7 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent(
-                                                                                                AuthorizationResultDto authorizationResultDto
+            AuthorizationResultDto authorizationResultDto
     ) {
         return new TransactionAuthorizationCompletedEvent(
                 TRANSACTION_ID,
@@ -243,8 +243,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionAuthorizationCompletedEvent transactionAuthorizationCompletedEvent(
-                                                                                                AuthorizationResultDto authorizationResultDto,
-                                                                                                String rnn
+            AuthorizationResultDto authorizationResultDto,
+            String rnn
     ) {
         return new TransactionAuthorizationCompletedEvent(
                 TRANSACTION_ID,
@@ -260,8 +260,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionAuthorizationCompleted transactionAuthorizationCompleted(
-                                                                                      TransactionAuthorizationCompletedEvent authorizedEvent,
-                                                                                      TransactionWithRequestedAuthorization transactionWithRequestedAuthorization
+            TransactionAuthorizationCompletedEvent authorizedEvent,
+            TransactionWithRequestedAuthorization transactionWithRequestedAuthorization
     ) {
         return new TransactionAuthorizationCompleted(
                 transactionWithRequestedAuthorization,
@@ -286,8 +286,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithClosureError transactionWithClosureError(
-                                                                          TransactionClosureErrorEvent transactionClosureErrorEvent,
-                                                                          BaseTransactionWithPaymentToken transaction
+            TransactionClosureErrorEvent transactionClosureErrorEvent,
+            BaseTransactionWithPaymentToken transaction
     ) {
         return new TransactionWithClosureError(
                 transaction,
@@ -297,8 +297,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionClosed transactionClosed(
-                                                      BaseTransactionWithCompletedAuthorization transactionWithCompletedAuthorization,
-                                                      TransactionClosedEvent transactionClosedEvent
+            BaseTransactionWithCompletedAuthorization transactionWithCompletedAuthorization,
+            TransactionClosedEvent transactionClosedEvent
     ) {
         return new TransactionClosed(
                 transactionWithCompletedAuthorization,
@@ -308,8 +308,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithUserReceiptOk transactionWithUserReceiptOk(
-                                                                            BaseTransactionWithRequestedUserReceipt baseTransaction,
-                                                                            TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent
+            BaseTransactionWithRequestedUserReceipt baseTransaction,
+            TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent
     ) {
         return new TransactionWithUserReceiptOk(
                 baseTransaction,
@@ -319,8 +319,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithUserReceiptKo transactionWithUserReceiptKo(
-                                                                            BaseTransactionWithRequestedUserReceipt baseTransaction,
-                                                                            TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent
+            BaseTransactionWithRequestedUserReceipt baseTransaction,
+            TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent
     ) {
         return new TransactionWithUserReceiptKo(
                 baseTransaction,
@@ -330,7 +330,7 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionUserReceiptAddedEvent transactionUserReceiptAddedEvent(
-                                                                                    TransactionUserReceiptData data
+            TransactionUserReceiptData data
     ) {
         return new TransactionUserReceiptAddedEvent(
                 TRANSACTION_ID,
@@ -350,72 +350,72 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionExpired transactionExpired(
-                                                        BaseTransactionWithRequestedAuthorization transaction,
-                                                        TransactionExpiredEvent expiredEvent
+            BaseTransactionWithRequestedAuthorization transaction,
+            TransactionExpiredEvent expiredEvent
     ) {
         return new TransactionExpired(transaction, expiredEvent);
     }
 
     @Nonnull
     public static TransactionRefunded transactionRefunded(
-                                                          BaseTransactionWithRefundRequested transaction,
-                                                          TransactionRefundedEvent transactionRefundedEvent
+            BaseTransactionWithRefundRequested transaction,
+            TransactionRefundedEvent transactionRefundedEvent
     ) {
         return new TransactionRefunded(transaction, transactionRefundedEvent);
     }
 
     @Nonnull
     public static TransactionUnauthorized transactionUnauthorized(
-                                                                  BaseTransactionWithCompletedAuthorization transaction,
-                                                                  TransactionClosureFailedEvent transactionClosureFailedEvent
+            BaseTransactionWithCompletedAuthorization transaction,
+            TransactionClosureFailedEvent transactionClosureFailedEvent
     ) {
         return new TransactionUnauthorized(transaction, transactionClosureFailedEvent);
     }
 
     @Nonnull
     public static TransactionUserCanceled transactionUserCanceled(
-                                                                  BaseTransactionWithCancellationRequested transaction,
-                                                                  TransactionClosedEvent transactionClosedEvent
+            BaseTransactionWithCancellationRequested transaction,
+            TransactionClosedEvent transactionClosedEvent
     ) {
         return new TransactionUserCanceled(transaction, transactionClosedEvent);
     }
 
     @Nonnull
     public static TransactionWithCancellationRequested transactionWithCancellationRequested(
-                                                                                            BaseTransactionWithPaymentToken baseTransaction,
-                                                                                            TransactionUserCanceledEvent transactionUserCanceledEvent
+            BaseTransactionWithPaymentToken baseTransaction,
+            TransactionUserCanceledEvent transactionUserCanceledEvent
     ) {
         return new TransactionWithCancellationRequested(baseTransaction, transactionUserCanceledEvent);
     }
 
     @Nonnull
     public static TransactionCancellationExpired transactionCancellationExpired(
-                                                                                BaseTransactionWithCancellationRequested baseTransaction,
-                                                                                TransactionExpiredEvent transactionExpiredEvent
+            BaseTransactionWithCancellationRequested baseTransaction,
+            TransactionExpiredEvent transactionExpiredEvent
     ) {
         return new TransactionCancellationExpired(baseTransaction, transactionExpiredEvent);
     }
 
     @Nonnull
     public static TransactionExpiredNotAuthorized transactionExpiredNotAuthorized(
-                                                                                  BaseTransaction transaction,
-                                                                                  TransactionExpiredEvent transactionExpiredEvent
+            BaseTransaction transaction,
+            TransactionExpiredEvent transactionExpiredEvent
     ) {
         return new TransactionExpiredNotAuthorized(transaction, transactionExpiredEvent);
     }
 
     @Nonnull
     public static TransactionWithRefundError transactionWithRefundError(
-                                                                        BaseTransactionWithRefundRequested baseTransaction,
-                                                                        TransactionRefundErrorEvent transactionRefundErrorEvent
+            BaseTransactionWithRefundRequested baseTransaction,
+            TransactionRefundErrorEvent transactionRefundErrorEvent
     ) {
         return new TransactionWithRefundError(baseTransaction, transactionRefundErrorEvent);
     }
 
     @Nonnull
     public static TransactionWithRefundRequested transactionWithRefundRequested(
-                                                                                BaseTransactionWithRequestedAuthorization baseTransaction,
-                                                                                TransactionRefundRequestedEvent transactionRefundRequestedEvent
+            BaseTransactionWithRequestedAuthorization baseTransaction,
+            TransactionRefundRequestedEvent transactionRefundRequestedEvent
     ) {
         return new TransactionWithRefundRequested(
                 baseTransaction,
@@ -472,7 +472,7 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionRefundRequestedEvent transactionRefundRequestedEvent(
-                                                                                  BaseTransaction baseTransaction
+            BaseTransaction baseTransaction
     ) {
         return new TransactionRefundRequestedEvent(
                 TRANSACTION_ID,
@@ -490,7 +490,7 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionUserReceiptAddErrorEvent transactionUserReceiptAddErrorEvent(
-                                                                                          TransactionUserReceiptData data
+            TransactionUserReceiptData data
     ) {
         return new TransactionUserReceiptAddErrorEvent(
                 TRANSACTION_ID,
@@ -508,8 +508,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithUserReceiptError transactionWithUserReceiptError(
-                                                                                  BaseTransactionWithRequestedUserReceipt baseTransaction,
-                                                                                  TransactionUserReceiptAddErrorEvent transactionUserReceiptAddErrorEvent
+            BaseTransactionWithRequestedUserReceipt baseTransaction,
+            TransactionUserReceiptAddErrorEvent transactionUserReceiptAddErrorEvent
     ) {
         return new TransactionWithUserReceiptError(
                 baseTransaction,
@@ -519,8 +519,8 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static Transaction transactionDocument(
-                                                  TransactionStatusDto transactionStatus,
-                                                  ZonedDateTime creationDateTime
+            TransactionStatusDto transactionStatus,
+            ZonedDateTime creationDateTime
     ) {
         return new Transaction(
                 TRANSACTION_ID,
@@ -553,15 +553,15 @@ public class TransactionTestUtils {
 
     @Nonnull
     public static TransactionWithRequestedUserReceipt transactionWithRequestedUserReceipt(
-                                                                                          BaseTransactionClosed baseTransactionClosed,
-                                                                                          TransactionUserReceiptRequestedEvent transactionUserReceiptRequestedEvent
+            BaseTransactionClosed baseTransactionClosed,
+            TransactionUserReceiptRequestedEvent transactionUserReceiptRequestedEvent
     ) {
         return new TransactionWithRequestedUserReceipt(baseTransactionClosed, transactionUserReceiptRequestedEvent);
     }
 
     @Nonnull
     public static TransactionUserReceiptRequestedEvent transactionUserReceiptRequestedEvent(
-                                                                                            TransactionUserReceiptData transactionUserReceiptData
+            TransactionUserReceiptData transactionUserReceiptData
     ) {
         return new TransactionUserReceiptRequestedEvent(
                 TRANSACTION_ID,
@@ -578,6 +578,7 @@ public class TransactionTestUtils {
                 AMOUNT,
                 DUE_DATE,
                 PAYMENT_TOKEN,
+                ZonedDateTime.now().toString(),
                 new IdempotencyKey(IDEMPOTENCY_KEY),
                 List.of(
                         new PaymentTransferInfo(
@@ -599,8 +600,8 @@ public class TransactionTestUtils {
                 .stream()
                 .reduce(
                         (
-                         trx,
-                         event
+                                trx,
+                                event
                         ) -> ((it.pagopa.ecommerce.commons.domain.v1.Transaction) trx).applyEvent(event)
                 )
                 .orElseThrow(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add activation date into PaymentRequstInfo redis cache entity.
The activation date will be set when the transaction is first created and will be used to monitor subsequent activations against the payment token validity time left
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed in order to monitor subsequent transactions activations payment token validity time left
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.