### PR TITLE
fix(events): fix Spring annotation in inherited `BaseTransaction`'s fields

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/documents/BaseTransactionEvent.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/BaseTransactionEvent.java
@@ -1,8 +1,11 @@
 package it.pagopa.ecommerce.commons.documents;
 
+import com.azure.spring.data.cosmos.core.mapping.PartitionKey;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
 
 /**
  * <p>
@@ -14,9 +17,12 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Document(collection = "eventstore")
 public abstract class BaseTransactionEvent<T> {
+    @Id
     private String id;
 
+    @PartitionKey
     private String transactionId;
 
     private String creationDate;

--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionEvent.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v1/TransactionEvent.java
@@ -1,10 +1,8 @@
 package it.pagopa.ecommerce.commons.documents.v1;
 
-import com.azure.spring.data.cosmos.core.mapping.PartitionKey;
 import it.pagopa.ecommerce.commons.documents.BaseTransactionEvent;
 import it.pagopa.ecommerce.commons.domain.v1.TransactionEventCode;
 import lombok.*;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.UUID;
@@ -24,13 +22,6 @@ import static java.time.ZonedDateTime.now;
 @ToString
 public abstract sealed class TransactionEvent<T> extends
         BaseTransactionEvent<T>permits BaseTransactionClosureEvent,TransactionActivatedEvent,TransactionAuthorizationCompletedEvent,TransactionAuthorizationRequestedEvent,TransactionClosureErrorEvent,TransactionClosureRetriedEvent,TransactionExpiredEvent,TransactionRefundErrorEvent,TransactionRefundRequestedEvent,TransactionRefundRetriedEvent,TransactionRefundedEvent,TransactionUserReceiptRequestedEvent,TransactionUserCanceledEvent,TransactionUserReceiptAddErrorEvent,TransactionUserReceiptAddRetriedEvent,TransactionUserReceiptAddedEvent {
-
-    @Id
-    private String id;
-
-    @PartitionKey
-    private String transactionId;
-
     private TransactionEventCode eventCode;
 
     TransactionEvent(
@@ -52,8 +43,6 @@ public abstract sealed class TransactionEvent<T> extends
                             .formatted(transactionId)
             );
         }
-        this.id = UUID.randomUUID().toString();
-        this.transactionId = transactionId;
         this.eventCode = eventCode;
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* fix Spring annotation in inherited `BaseTransactions` fiels

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This PR fixes a runtime loading issue of event classes. In particular Spring cannot disambiguate between base class and child class when applying annotation to fields with the same name.

This fix moves the annotations to the base class.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.