### PR TITLE
[CHK-1851] Fix action type and amount in orders/build nexi api invocation

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/client/NpgClient.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/client/NpgClient.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 public class NpgClient {
 
     private static final String CREATE_HOSTED_ORDER_REQUEST_VERSION = "2";
-    private static final String CREATE_HOSTED_ORDER_REQUEST_VERIFY_AMOUNT = "0";
+    private static final String CREATE_HOSTED_ORDER_REQUEST_PAY_AMOUNT = "1";
     private static final String CREATE_HOSTED_ORDER_REQUEST_CURRENCY_EUR = "EUR";
     private static final String CREATE_HOSTED_ORDER_REQUEST_LANGUAGE_ITA = "ITA";
     private static final String NPG_CORRELATION_ID_ATTRIBUTE_NAME = "npg.correlation_id";
@@ -512,14 +512,14 @@ public class NpgClient {
                 .order(
                         new OrderDto()
                                 .orderId(orderId)
-                                .amount(CREATE_HOSTED_ORDER_REQUEST_VERIFY_AMOUNT)
+                                .amount(CREATE_HOSTED_ORDER_REQUEST_PAY_AMOUNT)
                                 .currency(CREATE_HOSTED_ORDER_REQUEST_CURRENCY_EUR)
                                 .customerId(customerId)
                 )
                 .paymentSession(
                         new PaymentSessionDto()
-                                .actionType(ActionTypeDto.VERIFY)
-                                .amount(CREATE_HOSTED_ORDER_REQUEST_VERIFY_AMOUNT)
+                                .actionType(ActionTypeDto.PAY)
+                                .amount(CREATE_HOSTED_ORDER_REQUEST_PAY_AMOUNT)
                                 .language(CREATE_HOSTED_ORDER_REQUEST_LANGUAGE_ITA)
                                 .paymentService(paymentMethod.serviceName)
                                 .resultUrl(resultUrl.toString())

--- a/src/test/java/it/pagopa/ecommerce/commons/client/NpgClientTests.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/client/NpgClientTests.java
@@ -35,7 +35,7 @@ class NpgClientTests {
     private static final String ORDER_REQUEST_VERSION = "2";
     private static final String MERCHANT_URL = "localhost/merchant";
     private static final String ORDER_REQUEST_ORDER_ID = "orderId";
-    private static final String ORDER_REQUEST_AMOUNT = "0";
+    private static final String ORDER_REQUEST_PAY = "1";
     private static final String ORDER_REQUEST_CURRENCY_EUR = "EUR";
     private static final String ORDER_REQUEST_CUSTOMER_ID = "customerId";
     private static final String ORDER_REQUEST_PAYMENT_SERVICE_CARDS = NpgClient.PaymentMethod.CARDS.serviceName;
@@ -322,7 +322,7 @@ class NpgClientTests {
                         npgClient.confirmPayment(
                                 correlationUUID,
                                 SESSION_ID,
-                                new BigDecimal(ORDER_REQUEST_AMOUNT),
+                                new BigDecimal(ORDER_REQUEST_PAY),
                                 MOCKED_API_KEY
                         )
                 )
@@ -362,7 +362,7 @@ class NpgClientTests {
                         npgClient.confirmPayment(
                                 correlationUUID,
                                 SESSION_ID,
-                                new BigDecimal(ORDER_REQUEST_AMOUNT),
+                                new BigDecimal(ORDER_REQUEST_PAY),
                                 MOCKED_API_KEY
                         )
                 )
@@ -391,15 +391,15 @@ class NpgClientTests {
                 .order(
                         new OrderDto()
                                 .orderId(ORDER_REQUEST_ORDER_ID)
-                                .amount(ORDER_REQUEST_AMOUNT)
+                                .amount(ORDER_REQUEST_PAY)
                                 .currency(ORDER_REQUEST_CURRENCY_EUR)
                                 .customerId(ORDER_REQUEST_CUSTOMER_ID)
                 )
                 .paymentSession(
                         new PaymentSessionDto()
                                 .paymentService(ORDER_REQUEST_PAYMENT_SERVICE_CARDS)
-                                .amount(ORDER_REQUEST_AMOUNT)
-                                .actionType(ActionTypeDto.VERIFY)
+                                .amount(ORDER_REQUEST_PAY)
+                                .actionType(ActionTypeDto.PAY)
                                 .language(ORDER_REQUEST_LANGUAGE_ITA)
                                 .cancelUrl(CANCEL_URL)
                                 .notificationUrl(NOTIFICATION_URL)
@@ -427,7 +427,7 @@ class NpgClientTests {
     private ConfirmPaymentRequestDto buildTestConfirmPaymentRequestDto() {
         return new ConfirmPaymentRequestDto()
                 .sessionId(SESSION_ID)
-                .amount(ORDER_REQUEST_AMOUNT);
+                .amount(ORDER_REQUEST_PAY);
     }
 
 }


### PR DESCRIPTION
Switch action type to PAY in orders/build invocation (nexi api)

#### List of Changes

Switch the action type to PAY and consequently the amount to an integer greater than 0 as api specs requires.

#### Motivation and Context

To align the the nexi api invocation with the nexi specs document

#### How Has This Been Tested?

JUnit test has been runned. This PR will be tested in the module that use the npg client

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.