### PR TITLE
[CHK-1862] feat(refund): add refund payment method for npg client

### DIFF
--- a/clients/api-specs/npg.yaml
+++ b/clients/api-specs/npg.yaml
@@ -673,6 +673,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServerError'
+  /psp/api/v1/operations/{operationId}/refunds:
+    post:
+      tags:
+        - Payment Services
+      summary: Create an order and initiates a payment through build functionality.
+      description: "This service is targeted to ecommerce platforms requiring to implement the payment pages in line with their own dedicated UI style guidelines. The service will return a list of fields expressed in JSON format, to be translated into HTML by the ecommerce platform web app. If the paymentService field is valued at CARDS the service will return a list of fields for the CARD_DATA_COLLECTION without going through the PAYMENT_METHOD_SELECTION state and if it's valued with an APM the service will return an url where the customer should be redirected."
+      parameters:
+        - name: operationId
+          required: true
+          in: path
+          schema:
+            type: string
+          description: ID of the operation
+        - name: Correlation-Id
+          in: header
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: "Mandatory field to be valued with a UUID to be renewed at every call. The purpose of the field is to allow referring to a specific call for any integration or maintenance activity."
+        - name: x-api-key
+          in: header
+          required: true
+          schema:
+            type: string
+          description: "Default api key"
+        - name: Idempotency-key
+          in: header
+          required: true
+          schema:
+            type: string
+          description: "Idempotence key"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundRequest'
+        required: true
+      responses:
+        "200":
+          description: "In case of success, the service returns a list of fields to be rendered in the ecomm web app."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefundResponse'
+        "400":
+          description: Invalid request data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientError'
+        "404":
+          description: Operation not found
+        "401":
+          description: Unauthorized
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerError'
 components:
   schemas:
     StateResponse:
@@ -879,6 +940,32 @@ components:
           $ref: '#/components/schemas/Order'
         paymentSession:
           $ref: '#/components/schemas/PaymentSession'
+    RefundRequest:
+      type: object
+      properties:
+        amount:
+          type: string
+          example: "100"
+          description: Amount of the refund in eurocent
+        currency:
+          type: string
+          example: "EUR"
+          description: Currency of the amount
+        description:
+          type: string
+          example: "Goods have been shipped"
+          description: Reason for refunding
+    RefundResponse:
+      type: object
+      properties:
+        operationId:
+          type: string
+          example: "3470744"
+          description: ID operation
+        operationTime:
+          type: string
+          example: "2022-09-01T01:20:00.001Z"
+          description: Datetime of the operation
     ClientError:
       type: object
       properties:

--- a/src/main/java/it/pagopa/ecommerce/commons/client/NpgClient.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/client/NpgClient.java
@@ -36,6 +36,7 @@ public class NpgClient {
     private static final String NPG_CORRELATION_ID_ATTRIBUTE_NAME = "npg.correlation_id";
 
     private static final String NPG_ERROR_CODES_ATTRIBUTE_NAME = "npg.error_codes";
+    private static final String EUR_CURRENCY = "EUR";
 
     /**
      * The npg Api
@@ -505,7 +506,6 @@ public class NpgClient {
      * @param idempotenceKey the idempotenceKey used to identify a refund reqeust
      *                       for the same transaction
      * @param grandTotal     the grand total to be refunded
-     * @param currency       the currency of the refund
      * @param defaultApiKey  default API key
      * @return An object containing the state of the transaction and the info about
      *         operation details.
@@ -515,7 +515,6 @@ public class NpgClient {
                                                  @NotNull String operationId,
                                                  @NotNull String idempotenceKey,
                                                  @NotNull BigDecimal grandTotal,
-                                                 @NotNull String currency,
                                                  @NonNull String defaultApiKey
     ) {
         return Mono.using(
@@ -528,7 +527,7 @@ public class NpgClient {
                         correlationId,
                         defaultApiKey,
                         idempotenceKey,
-                        new RefundRequestDto().amount(grandTotal.toString()).currency(currency)
+                        new RefundRequestDto().amount(grandTotal.toString()).currency(EUR_CURRENCY)
                 ).doOnError(
                         WebClientResponseException.class,
                         e -> log.info(

--- a/src/test/java/it/pagopa/ecommerce/commons/client/NpgClientTests.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/client/NpgClientTests.java
@@ -358,7 +358,6 @@ class NpgClientTests {
                                 OPERATION_ID,
                                 IDEMPOTENCE_KEY,
                                 BigDecimal.valueOf(Integer.parseInt(AMOUNT)),
-                                CURRENCY,
                                 MOCKED_API_KEY
                         )
                 )
@@ -445,7 +444,6 @@ class NpgClientTests {
                                 OPERATION_ID,
                                 IDEMPOTENCE_KEY,
                                 BigDecimal.valueOf(Integer.parseInt(AMOUNT)),
-                                CURRENCY,
                                 MOCKED_API_KEY
                         )
                 )


### PR DESCRIPTION
Add the npg cancel payment client implementation
This feature is fully  backwards-compatible, since it is only a method adding

#### List of Changes

- Add the npg client refund payment invocation (https://developer.nexi.it/it/api/post-build-cancel)
- Add test for new method of npgClient

#### Motivation and Context

To handle refund for transactions payed via npg

#### How Has This Been Tested?

Unit test ran

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.