### PR TITLE
refactor(auto-pr): trigger action on tag push rather than on release publishing

### DIFF
--- a/.github/workflows/create_pr_with_version_update.yaml
+++ b/.github/workflows/create_pr_with_version_update.yaml
@@ -2,14 +2,28 @@ name: Create PR on eCommerce project with version update
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+  push:
+    tags:
+      - '*'
 
 permissions:
   pull-requests: write
 
 jobs:
+  on_main_branch_check:
+    runs-on: ubuntu-latest
+    outputs:
+      on_main: ${{ steps.contains_tag.outputs.retval }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rickstaa/action-contains-tag@412ce324d3c61b7db1af82bc20984601b990bc19
+        id: contains_tag
+        with:
+          reference: "main"
+          tag: "${{ github.ref }}"
+
   create_pr:
+    if: ${{ needs.on_main_branch_check.outputs.on_main == 'true' }}
     environment: prod
     strategy:
       matrix:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Actions triggered automatically via `release` with `published` are executed in their own branch and not on `main`.
The action has been refactored to use tags and check whether the tag was applied on `main` in order to fix permission issues.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Prayers

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.