### PR TITLE
fix(auto-pr): Refactor action to trigger on GitHub release rather than on tag push

### DIFF
--- a/.github/workflows/create_pr_with_version_update.yaml
+++ b/.github/workflows/create_pr_with_version_update.yaml
@@ -2,30 +2,15 @@ name: Create PR on eCommerce project with version update
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - '*'
+  release:
+    types:
+      - published
 
 permissions:
   pull-requests: write
 
 jobs:
-  on_main_branch_check:
-    runs-on: ubuntu-latest
-    outputs:
-      on_main: ${{ steps.contains_tag.outputs.retval }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: rickstaa/action-contains-tag@412ce324d3c61b7db1af82bc20984601b990bc19
-        id: contains_tag
-        with:
-          reference: "main"
-          tag: "${{ github.ref }}"
-
   create_pr:
-    if: ${{ needs.on_main_branch_check.outputs.on_main == 'true' }}
     environment: prod
     strategy:
       matrix:

--- a/.github/workflows/create_pr_with_version_update.yaml
+++ b/.github/workflows/create_pr_with_version_update.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: pagopa/pagopa-ecommerce-commons
+          path: pagopa-ecommerce-commons
 
       - name: Get latest tag
         id: latest_tag
@@ -35,6 +36,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: pagopa/${{ matrix.repo }}
+          path: ${{ matrix.repo }}
 
       - name: Replace old version with new version (Maven)
         uses: jacobtomlinson/gha-find-replace@a51bbcd94d000df9ca0fcb54ec8be69aad8374b0

--- a/.github/workflows/create_pr_with_version_update.yaml
+++ b/.github/workflows/create_pr_with_version_update.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: pagopa/${{ matrix.repo }}
-          path: ${{ matrix.repo }}
 
       - name: Replace old version with new version (Maven)
         uses: jacobtomlinson/gha-find-replace@a51bbcd94d000df9ca0fcb54ec8be69aad8374b0

--- a/.github/workflows/create_pr_with_version_update.yaml
+++ b/.github/workflows/create_pr_with_version_update.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get latest tag
         id: latest_tag
-        uses: WyriHaximus/github-action-get-previous-tag@385a2a0b6abf6c2efeb95adfac83d96d6f968e0c
+        uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435
 
       - name: Replace old version with new version (Maven)
         uses: jacobtomlinson/gha-find-replace@a51bbcd94d000df9ca0fcb54ec8be69aad8374b0

--- a/.github/workflows/create_pr_with_version_update.yaml
+++ b/.github/workflows/create_pr_with_version_update.yaml
@@ -22,14 +22,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout pagopa/${{ matrix.repo }}
+      - name: Checkout pagopa/pagopa-ecommerce-commons
         uses: actions/checkout@v3
         with:
-          repository: pagopa/${{ matrix.repo }}
+          repository: pagopa/pagopa-ecommerce-commons
 
       - name: Get latest tag
         id: latest_tag
         uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435
+
+      - name: Checkout pagopa/${{ matrix.repo }}
+        uses: actions/checkout@v3
+        with:
+          repository: pagopa/${{ matrix.repo }}
 
       - name: Replace old version with new version (Maven)
         uses: jacobtomlinson/gha-find-replace@a51bbcd94d000df9ca0fcb54ec8be69aad8374b0

--- a/.github/workflows/create_pr_with_version_update.yaml
+++ b/.github/workflows/create_pr_with_version_update.yaml
@@ -22,16 +22,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout pagopa/pagopa-ecommerce-commons
-        uses: actions/checkout@v3
-        with:
-          repository: pagopa/pagopa-ecommerce-commons
-          path: pagopa-ecommerce-commons
-
-      - name: Get latest tag
-        id: latest_tag
-        uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435
-
       - name: Checkout pagopa/${{ matrix.repo }}
         uses: actions/checkout@v3
         with:
@@ -42,7 +32,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@a51bbcd94d000df9ca0fcb54ec8be69aad8374b0
         with:
           find: "<pagopa-ecommerce-commons.version>\\d+\\.\\d+\\.\\d+</pagopa-ecommerce-commons.version>"
-          replace: "<pagopa-ecommerce-commons.version>${{ steps.latest_tag.outputs.tag }}</pagopa-ecommerce-commons.version>"
+          replace: "<pagopa-ecommerce-commons.version>$GITHUB_REF</pagopa-ecommerce-commons.version>"
           regex: true
           include: "pom.xml"
 
@@ -50,19 +40,19 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@a51bbcd94d000df9ca0fcb54ec8be69aad8374b0
         with:
           find: "val ecommerceCommonsVersion = \"\\d+\\.\\d+\\.\\d+\""
-          replace: "val ecommerceCommonsVersion = \"${{ steps.latest_tag.outputs.tag }}\""
+          replace: "val ecommerceCommonsVersion = \"$GITHUB_REF\""
           regex: true
           include: "build.gradle.kts"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
         with:
-          branch: "update-commons-${{ steps.latest_tag.outputs.tag }}"
+          branch: "update-commons-$GITHUB_REF"
           token: ${{ secrets.PR_GITHUB_TOKEN }}
           author: pagopa-platform-github-bot <pagopa-github-bot@pagopa.it>
           committer: pagopa-platform-github-bot <pagopa-github-bot@pagopa.it>
-          commit-message: "chore(deps): update `commons` version to ${{ steps.latest_tag.outputs.tag }}"
-          title: "chore(deps): update `commons` version to ${{ steps.latest_tag.outputs.tag }}"
+          commit-message: "chore(deps): update `commons` version to $GITHUB_REF"
+          title: "chore(deps): update `commons` version to $GITHUB_REF"
           body: |
             <!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
             <!--- Even if we are all from our internal team, we may not be on the same page. -->
@@ -72,7 +62,7 @@ jobs:
             #### List of Changes
             
             <!--- Describe your changes in detail -->
-            * update `pagopa-ecommerce-commons` version to ${{ steps.latest_tag.outputs.tag }}
+            * update `pagopa-ecommerce-commons` version to $GITHUB_REF
             
             #### Motivation and Context
             <!--- Why is this change required? What problem does it solve? -->


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
 * refactor action to trigger on GH release
 * use different action to get latest tag
 * fix missing checkout of pagopa-ecommerce-commons to get tag
 * use different paths for repos
 * use GITHUB_REF instead of computing latest tag


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.