### PR TITLE
fix(event-reduce): add reduce logic to recover expired transaction

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionExpired.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v1/TransactionExpired.java
@@ -2,6 +2,8 @@ package it.pagopa.ecommerce.commons.domain.v1;
 
 import it.pagopa.ecommerce.commons.documents.v1.TransactionExpiredEvent;
 import it.pagopa.ecommerce.commons.documents.v1.TransactionRefundRequestedEvent;
+import it.pagopa.ecommerce.commons.documents.v1.TransactionUserReceiptRequestedEvent;
+import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransactionClosed;
 import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransactionExpired;
 import it.pagopa.ecommerce.commons.domain.v1.pojos.BaseTransactionWithRequestedAuthorization;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
@@ -44,13 +46,20 @@ public final class TransactionExpired extends BaseTransactionExpired implements 
      */
     @Override
     public Transaction applyEvent(Object event) {
-        if (event instanceof TransactionRefundRequestedEvent e) {
-            return new TransactionWithRefundRequested(
+        return switch (event) {
+            case TransactionRefundRequestedEvent e -> new TransactionWithRefundRequested(
                     this.getTransactionAtPreviousState(),
                     e
             );
-        }
-        return this;
+            case TransactionUserReceiptRequestedEvent e -> {
+                if (getTransactionAtPreviousState() instanceof BaseTransactionClosed baseTransactionClosed) {
+                    yield new TransactionWithRequestedUserReceipt(baseTransactionClosed, e);
+                } else {
+                    yield this;
+                }
+            }
+            default -> this;
+        };
     }
 
     /**


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add state transition from `EXPIRED` back to `NOTIFICATION_REQUESTED` for v1 events
<!--- Describe your changes in detail -->

#### Motivation and Context
Add state transition from `EXPIRED` to `NOTIFICATION_REQUESTED` in order to make sendPaymentResult processing available also for those transaction that have been marked as expired after the 65 mins timeout
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.