### PR TITLE
[CHK-2321] feat(checkout-redirect): add `CheckoutRedirectPspApiKeysConfig` bean to hold Checkout Redirect PSP API keys

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectConfigurationException.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectConfigurationException.java
@@ -9,14 +9,16 @@ public class CheckoutRedirectConfigurationException extends RuntimeException {
     /**
      * Constructor
      *
-     * @param errorCause error cause description
+     * @param errorCause        error cause description
+     * @param configurationType configuration type
      */
     public CheckoutRedirectConfigurationException(
-            String errorCause
+            String errorCause,
+            CheckoutRedirectConfigurationType configurationType
     ) {
         super(
-                "Error parsing Checkout Redirect PSP api keys configuration, cause: %s"
-                        .formatted(errorCause)
+                "Error parsing Checkout Redirect PSP %s configuration, cause: %s"
+                        .formatted(configurationType, errorCause)
         );
     }
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectConfigurationException.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectConfigurationException.java
@@ -1,0 +1,22 @@
+package it.pagopa.ecommerce.commons.exceptions;
+
+/**
+ * Exception thrown when NPG per PSP api key configuration cannot be
+ * successfully parsed
+ */
+public class CheckoutRedirectConfigurationException extends RuntimeException {
+
+    /**
+     * Constructor
+     *
+     * @param errorCause error cause description
+     */
+    public CheckoutRedirectConfigurationException(
+            String errorCause
+    ) {
+        super(
+                "Error parsing Checkout Redirect PSP api keys configuration, cause: %s"
+                        .formatted(errorCause)
+        );
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectConfigurationType.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectConfigurationType.java
@@ -1,0 +1,13 @@
+package it.pagopa.ecommerce.commons.exceptions;
+
+/**
+ * Enumeration containing possible types of Checkout Redirect configuration.
+ * Each enum variant maps to a different configuration property. These are kept
+ * separate to separate secrets from common configurations.
+ */
+public enum CheckoutRedirectConfigurationType {
+    /**
+     * Configuration for PSP API keys
+     */
+    API_KEYS;
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectConfigurationType.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectConfigurationType.java
@@ -9,5 +9,13 @@ public enum CheckoutRedirectConfigurationType {
     /**
      * Configuration for PSP API keys
      */
-    API_KEYS;
+    API_KEYS,
+    /**
+     * Configuration for URLs for the Checkout Redirect PSP API
+     */
+    BACKEND_URLS,
+    /**
+     * Configuration for PSPs logos
+     */
+    LOGOS
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectMissingPspRequestedException.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectMissingPspRequestedException.java
@@ -1,0 +1,26 @@
+package it.pagopa.ecommerce.commons.exceptions;
+
+import java.util.Set;
+
+/**
+ * Exception thrown when requesting an API key from NPG configuration for a
+ * nonexisting PSP
+ */
+public class CheckoutRedirectMissingPspRequestedException extends RuntimeException {
+
+    /**
+     * Constructor
+     *
+     * @param psp           requested PSP
+     * @param availablePsps currently configured PSPs
+     */
+    public CheckoutRedirectMissingPspRequestedException(
+            String psp,
+            Set<String> availablePsps
+    ) {
+        super(
+                "Requested API key for PSP %s. Available PSPs: %s"
+                        .formatted(psp, availablePsps)
+        );
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectMissingPspRequestedException.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/exceptions/CheckoutRedirectMissingPspRequestedException.java
@@ -11,16 +11,18 @@ public class CheckoutRedirectMissingPspRequestedException extends RuntimeExcepti
     /**
      * Constructor
      *
-     * @param psp           requested PSP
-     * @param availablePsps currently configured PSPs
+     * @param psp               requested PSP
+     * @param availablePsps     currently configured PSPs
+     * @param configurationType configuration type
      */
     public CheckoutRedirectMissingPspRequestedException(
             String psp,
-            Set<String> availablePsps
+            Set<String> availablePsps,
+            CheckoutRedirectConfigurationType configurationType
     ) {
         super(
-                "Requested API key for PSP %s. Available PSPs: %s"
-                        .formatted(psp, availablePsps)
+                "Requested configuration value in %s not available for PSP %s. Available PSPs: %s"
+                        .formatted(configurationType, psp, availablePsps)
         );
     }
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/CheckoutRedirectPspApiKeysConfig.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/CheckoutRedirectPspApiKeysConfig.java
@@ -1,0 +1,89 @@
+package it.pagopa.ecommerce.commons.utils;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.api.trace.Span;
+import io.vavr.control.Either;
+import it.pagopa.ecommerce.commons.exceptions.CheckoutRedirectConfigurationException;
+import it.pagopa.ecommerce.commons.exceptions.CheckoutRedirectMissingPspRequestedException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+
+/**
+ * This class take cares of parsing PSP api keys configuration for Checkout
+ * Redirect
+ */
+@Slf4j
+public class CheckoutRedirectPspApiKeysConfig {
+
+    private final Map<String, String> configuration;
+
+    /**
+     * Constructor
+     *
+     */
+    CheckoutRedirectPspApiKeysConfig(
+            Map<String, String> configuration
+    ) {
+        this.configuration = Collections.unmodifiableMap(configuration);
+    }
+
+    /**
+     * Return a map where valued with each psp id - api keys entries
+     *
+     * @param jsonSecretConfiguration - secret configuration json representation
+     * @param pspToHandle             - psp expected to be present into
+     *                                configuration json
+     * @param objectMapper            - {@link ObjectMapper} used to parse input
+     *                                JSON
+     * @return either the parsed map or the related parsing exception
+     */
+    public static Either<CheckoutRedirectConfigurationException, CheckoutRedirectPspApiKeysConfig> parseApiKeyConfiguration(
+                                                                                                                            String jsonSecretConfiguration,
+                                                                                                                            Set<String> pspToHandle,
+                                                                                                                            ObjectMapper objectMapper
+    ) {
+        try {
+            Set<String> expectedKeys = new HashSet<>(pspToHandle);
+            Map<String, String> apiKeys = objectMapper
+                    .readValue(jsonSecretConfiguration, new TypeReference<HashMap<String, String>>() {
+                    });
+            Set<String> configuredKeys = apiKeys.keySet();
+            expectedKeys.removeAll(configuredKeys);
+            if (!expectedKeys.isEmpty()) {
+                return Either.left(
+                        new CheckoutRedirectConfigurationException(
+                                "Misconfigured api keys. Missing keys: %s".formatted(expectedKeys)
+                        )
+                );
+            }
+            return Either.right(new CheckoutRedirectPspApiKeysConfig(apiKeys));
+        } catch (JacksonException ignored) {
+            // exception here is ignored on purpose in order to avoid secret configuration
+            // logging in case of wrong configured json string object
+            return Either.left(new CheckoutRedirectConfigurationException("Invalid json configuration map"));
+        }
+    }
+
+    /**
+     * Retrieves an API key for a specific PSP
+     *
+     * @param psp the PSP you want the API key for
+     * @return the API key corresponding to the input PSP
+     */
+    public Either<CheckoutRedirectMissingPspRequestedException, String> get(String psp) {
+        if (configuration.containsKey(psp)) {
+            return Either.right(configuration.get(psp));
+        } else {
+            CheckoutRedirectMissingPspRequestedException checkoutRedirectMissingPspRequestedException = new CheckoutRedirectMissingPspRequestedException(
+                    psp,
+                    configuration.keySet()
+            );
+            Span.current().recordException(checkoutRedirectMissingPspRequestedException);
+
+            return Either.left(checkoutRedirectMissingPspRequestedException);
+        }
+    }
+}

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/CheckoutRedirectPspApiKeysConfig.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/CheckoutRedirectPspApiKeysConfig.java
@@ -7,6 +7,7 @@ import io.opentelemetry.api.trace.Span;
 import io.vavr.control.Either;
 import it.pagopa.ecommerce.commons.exceptions.CheckoutRedirectConfigurationException;
 import it.pagopa.ecommerce.commons.exceptions.CheckoutRedirectMissingPspRequestedException;
+import it.pagopa.ecommerce.commons.exceptions.CheckoutRedirectConfigurationType;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
@@ -55,7 +56,8 @@ public class CheckoutRedirectPspApiKeysConfig {
             if (!expectedKeys.isEmpty()) {
                 return Either.left(
                         new CheckoutRedirectConfigurationException(
-                                "Misconfigured api keys. Missing keys: %s".formatted(expectedKeys)
+                                "Misconfigured api keys. Missing keys: %s".formatted(expectedKeys),
+                                CheckoutRedirectConfigurationType.API_KEYS
                         )
                 );
             }
@@ -63,7 +65,12 @@ public class CheckoutRedirectPspApiKeysConfig {
         } catch (JacksonException ignored) {
             // exception here is ignored on purpose in order to avoid secret configuration
             // logging in case of wrong configured json string object
-            return Either.left(new CheckoutRedirectConfigurationException("Invalid json configuration map"));
+            return Either.left(
+                    new CheckoutRedirectConfigurationException(
+                            "Invalid json configuration map",
+                            CheckoutRedirectConfigurationType.API_KEYS
+                    )
+            );
         }
     }
 
@@ -79,7 +86,8 @@ public class CheckoutRedirectPspApiKeysConfig {
         } else {
             CheckoutRedirectMissingPspRequestedException checkoutRedirectMissingPspRequestedException = new CheckoutRedirectMissingPspRequestedException(
                     psp,
-                    configuration.keySet()
+                    configuration.keySet(),
+                    CheckoutRedirectConfigurationType.API_KEYS
             );
             Span.current().recordException(checkoutRedirectMissingPspRequestedException);
 

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/CheckoutRedirectPspApiKeysConfigTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/CheckoutRedirectPspApiKeysConfigTest.java
@@ -1,0 +1,104 @@
+package it.pagopa.ecommerce.commons.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.api.trace.Span;
+import io.vavr.control.Either;
+import it.pagopa.ecommerce.commons.exceptions.CheckoutRedirectConfigurationException;
+import it.pagopa.ecommerce.commons.exceptions.CheckoutRedirectMissingPspRequestedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CheckoutRedirectPspApiKeysConfigTest {
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final String pspConfigurationJson = """
+            {
+                "psp1" : "key-psp1",
+                "psp2" : "key-psp2",
+                "psp3" : "key-psp3"
+            }
+            """;
+
+    private final Set<String> pspToHandle = Set.of("psp1", "psp2", "psp3");
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                    "psp1",
+                    "psp2",
+                    "psp3"
+            }
+    )
+    void shouldParsePspConfigurationSuccessfully(String pspId) throws CheckoutRedirectMissingPspRequestedException {
+        Either<CheckoutRedirectConfigurationException, CheckoutRedirectPspApiKeysConfig> pspConfiguration = CheckoutRedirectPspApiKeysConfig
+                .parseApiKeyConfiguration(
+                        pspConfigurationJson,
+                        pspToHandle,
+                        OBJECT_MAPPER
+                );
+
+        assertTrue(pspConfiguration.isRight());
+        assertEquals("key-%s".formatted(pspId), pspConfiguration.get().get(pspId).get());
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidJsonStructure() {
+        Either<CheckoutRedirectConfigurationException, CheckoutRedirectPspApiKeysConfig> pspConfiguration = CheckoutRedirectPspApiKeysConfig
+                .parseApiKeyConfiguration(
+                        "{",
+                        pspToHandle,
+                        OBJECT_MAPPER
+                );
+        assertTrue(pspConfiguration.isLeft());
+        assertEquals(
+                "Error parsing Checkout Redirect PSP api keys configuration, cause: Invalid json configuration map",
+                pspConfiguration.getLeft().getMessage()
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionForMissingPspId() {
+        Set<String> psps = new HashSet<>(pspToHandle);
+        psps.add("psp4");
+        Either<CheckoutRedirectConfigurationException, CheckoutRedirectPspApiKeysConfig> pspConfiguration = CheckoutRedirectPspApiKeysConfig
+                .parseApiKeyConfiguration(
+                        pspConfigurationJson,
+                        psps,
+                        OBJECT_MAPPER
+                );
+        assertTrue(pspConfiguration.isLeft());
+        assertEquals(
+                "Error parsing Checkout Redirect PSP api keys configuration, cause: Misconfigured api keys. Missing keys: [psp4]",
+                pspConfiguration.getLeft().getMessage()
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionForRetrievingMissingPsp() {
+        Either<CheckoutRedirectConfigurationException, CheckoutRedirectPspApiKeysConfig> pspConfiguration = CheckoutRedirectPspApiKeysConfig
+                .parseApiKeyConfiguration(
+                        pspConfigurationJson,
+                        pspToHandle,
+                        OBJECT_MAPPER
+                );
+
+        Span invalidSpan = Span.getInvalid();
+        try (MockedStatic<Span> s = Mockito.mockStatic(Span.class)) {
+            s.when(Span::current).thenReturn(invalidSpan);
+
+            assertTrue(pspConfiguration.isRight());
+            assertInstanceOf(
+                    CheckoutRedirectMissingPspRequestedException.class,
+                    pspConfiguration.get().get("missingPSP").getLeft()
+            );
+        }
+    }
+}

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/CheckoutRedirectPspApiKeysConfigTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/CheckoutRedirectPspApiKeysConfigTest.java
@@ -59,7 +59,7 @@ public class CheckoutRedirectPspApiKeysConfigTest {
                 );
         assertTrue(pspConfiguration.isLeft());
         assertEquals(
-                "Error parsing Checkout Redirect PSP api keys configuration, cause: Invalid json configuration map",
+                "Error parsing Checkout Redirect PSP API_KEYS configuration, cause: Invalid json configuration map",
                 pspConfiguration.getLeft().getMessage()
         );
     }
@@ -76,7 +76,7 @@ public class CheckoutRedirectPspApiKeysConfigTest {
                 );
         assertTrue(pspConfiguration.isLeft());
         assertEquals(
-                "Error parsing Checkout Redirect PSP api keys configuration, cause: Misconfigured api keys. Missing keys: [psp4]",
+                "Error parsing Checkout Redirect PSP API_KEYS configuration, cause: Misconfigured api keys. Missing keys: [psp4]",
                 pspConfiguration.getLeft().getMessage()
         );
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
 * add CheckoutRedirectPspApiKeysConfig bean to hold Checkout Redirect PSP API keys

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This PR adds an object representing Checkout Redirect PSP API keys to be used by `transactions-service` and `event-scheduler-service`

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.