### PR TITLE
feat: add LRU cache implementation

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/utils/LRUCache.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/LRUCache.java
@@ -1,0 +1,162 @@
+package it.pagopa.ecommerce.commons.utils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Least recently used cache implementation. This cache leave in memory at most
+ * the configured maxItems number of entries. When add a new entry and the
+ * maxItems number if reached the least recently used record is removed leaving
+ * in cache only the records that have been used most recently. This check if
+ * performed associating to each entry in map the last hit timestamp that is the
+ * last timestamp when this entry has been retrieved. This cache is internally
+ * synchronized using a {@link ReentrantReadWriteLock} so that multiple reads
+ * can be performed concurrently locking in case of a write operations.
+ * Concurrent write operations will be serialized allowing for concurrent writes
+ * too
+ *
+ * @param <K> the mapping key type
+ * @param <V> the map value
+ */
+public class LRUCache<K, V> {
+
+    private final Map<K, LruCacheEntry<V>> internalCache = new HashMap<>();
+    private final long maxItems;
+
+    /**
+     * Reentrant read write lock used to synchronize concurrent cache access
+     */
+    private final ReadWriteLock lock;
+
+    record LruCacheEntry<V> (
+            V value,
+            long lastHitTimestamp
+    ) {
+        LruCacheEntry(V value) {
+            this(value, System.currentTimeMillis());
+        }
+    }
+
+    /**
+     * Constructor
+     *
+     * @param maxItems number of max allowed records into cache, must be a positive
+     *                 integer
+     * @throws IllegalArgumentException for 0 or negative maxItems input value
+     */
+    public LRUCache(long maxItems) {
+        this(maxItems, new ReentrantReadWriteLock());
+    }
+
+    LRUCache(
+            long maxItems,
+            ReadWriteLock lock
+    ) {
+        if (maxItems <= 0) {
+            throw new IllegalArgumentException(
+                    "Invalid maxItems: [%s], maxItems parameter must be >0".formatted(maxItems)
+            );
+        }
+        this.maxItems = maxItems;
+        this.lock = lock;
+    }
+
+    /**
+     * Add a new value into the cache, removing the least recently used one's if
+     * maxItems limit has been reached
+     *
+     * @param key   the key to associate to the element
+     * @param value the value to add to the cache
+     */
+    public void put(
+                    K key,
+                    V value
+    ) {
+        // acquire write lock
+        lock.writeLock().lock();
+        try {
+            // the internal cache doesn't contain the input key and the max items limit has
+            // been reached -> proceed to delete least recently used entry to leave space
+            // for the new entry
+            if (!internalCache.containsKey(key) && internalCache.size() == maxItems) {
+                removeLeastRecentlyUsedEntry();
+            }
+            internalCache.put(key, new LruCacheEntry<>(value));
+        } finally {
+            // release write lock
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Retrieve the value associated to the input key
+     *
+     * @param key the key to be searched for
+     * @return an optional containing the associated value to the key
+     */
+    public Optional<V> get(K key) {
+        // acquire write lock since each cache hit will write to cache table in order to
+        // update last hit timestamp
+        lock.writeLock().lock();
+        try {
+            LruCacheEntry<V> value = internalCache.get(key);
+            return Optional
+                    .ofNullable(value)
+                    .map(lruEntry -> {
+                        // there is a cache hit, update the last hit timestamp associated to the entry
+                        internalCache.put(key, new LruCacheEntry<>(lruEntry.value));
+                        return lruEntry.value;
+
+                    });
+        } finally {
+            // release write lock
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Returns the current internal cache map view
+     *
+     * @return an unmodifiable map containing all cache mappings
+     */
+    public Map<K, V> getInternalCacheMap() {
+        this.lock.readLock().lock();
+        try {
+            Map<K, V> mappings = new HashMap<>();
+            internalCache.forEach(
+                    (
+                     k,
+                     v
+                    ) -> mappings.put(k, v.value())
+            );
+            return Collections.unmodifiableMap(mappings);
+        } finally {
+            this.lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * This method will search for the entry that has least recently used and remove
+     * it from the internal cache
+     */
+    private void removeLeastRecentlyUsedEntry() {
+        K keyToRemove = null;
+        long oldHitTimestamp = Long.MAX_VALUE;
+        long currentHitTimestamp;
+        for (Map.Entry<K, LruCacheEntry<V>> entry : internalCache.entrySet()) {
+            currentHitTimestamp = entry.getValue().lastHitTimestamp;
+            if (oldHitTimestamp > currentHitTimestamp) {
+                oldHitTimestamp = currentHitTimestamp;
+                keyToRemove = entry.getKey();
+            }
+        }
+        if (keyToRemove != null) {
+            internalCache.remove(keyToRemove);
+        }
+    }
+
+}

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/LRUCacheTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/LRUCacheTest.java
@@ -1,0 +1,116 @@
+package it.pagopa.ecommerce.commons.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LRUCacheTest {
+
+    private final int cacheMaxItems = 5;
+
+    private final ReadWriteLock lock = Mockito.spy(new ReentrantReadWriteLock());
+    private final LRUCache<String, String> lruCache = new LRUCache<>(cacheMaxItems, lock);
+
+    @Test
+    void shouldAddAllElementsToCacheRemovingLeastRecentlyUsedOnes() {
+        // pre-conditions
+        List<String> elements = IntStream.range(0, 10).mapToObj(String::valueOf).toList();
+        Mono<Void> testMono = Flux
+                .fromIterable(elements)
+                // delay each element of 100 millis in order to have different last update
+                // timestamps
+                .delayElements(Duration.ofMillis(100))
+                .doOnNext(element -> {
+                    /*
+                     * Here we retrieve always the first two element in order to simulate a cache
+                     * hit for the first two and so that this two elements will be present into the
+                     * final cache (because their last hit timestamp will be updated before any new
+                     * element insertion into cache
+                     */
+                    lruCache.get("1");
+                    lruCache.get("2");
+                    lruCache.put(element, element);
+                }).collectList().then();
+        // test
+        StepVerifier
+                .create(
+                        testMono
+                ).expectNext()
+                .verifyComplete();
+        // assertions
+        Map<String, String> cacheView = lruCache.getInternalCacheMap();
+        // here we expected that LRU cache contains the 1 and 2 keys (the ones for which
+        // we trigger a cache hit during test before any insertion and the last added
+        // ones
+        Set<String> expectedKeys = Set.of("1", "2", "7", "8", "9");
+        assertEquals(cacheMaxItems, cacheView.size());
+        assertTrue(cacheView.keySet().containsAll(expectedKeys));
+
+    }
+
+    @Test
+    void shouldAddAllElementsHandlingConcurrentMapAccess() {
+        // pre-conditions
+        int concurrentItemsToAdd = 10000;
+        List<String> elements = IntStream.range(0, concurrentItemsToAdd).mapToObj(String::valueOf).toList();
+        Mono<Void> testMono = Flux
+                .fromIterable(elements)
+                .parallel(concurrentItemsToAdd)
+                .runOn(Schedulers.parallel())
+                .doOnNext(element -> lruCache.put(element, element))
+                .then();
+        // test
+        StepVerifier
+                .create(
+                        testMono
+                ).expectNext()
+                .verifyComplete();
+        // add a new element to cache that has to be present deleting the internal least
+        // recently added ones
+        lruCache.put("1", "1");
+        // assertions
+        Map<String, String> cacheView = lruCache.getInternalCacheMap();
+        assertEquals(cacheMaxItems, cacheView.size());
+        assertTrue(cacheView.containsKey("1"));
+    }
+
+    @Test
+    void shouldRetrieveValuesFromCacheSuccessfully() {
+        // pre-conditions
+        lruCache.put("1", "1");
+        // assertions
+        Optional<String> cacheHitValue = lruCache.get("1");
+        Optional<String> missingKey = lruCache.get("2");
+        assertTrue(cacheHitValue.isPresent());
+        assertEquals("1", cacheHitValue.get());
+        assertTrue(missingKey.isEmpty());
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            ints = {
+                    0,
+                    Integer.MIN_VALUE
+            }
+    )
+    void shouldThrowExceptionForInvalidMaxItemsValue(int invalidMaxItems) {
+        assertThrows(IllegalArgumentException.class, () -> new LRUCache<>(invalidMaxItems));
+    }
+
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Implemented LRU (Least recently used) cache.
This in-memory cache implementation, that internally relies on java HashMap, keep at most the defined amount of entity in memory. When a new items has to be add to a full cache it will be add removing the least recently used item.
This way only the most recently used items will be keep in memory and old ones will be removed.
<!--- Describe your changes in detail -->

#### Motivation and Context
This implementation will be used in redirection business logic implementation task were an api client will be create (lazily) for each redirection integrated PSP. Only the most recent used PSPs api client will be keep in memory removing those that have not been used recently
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.