### PR TITLE
feat(redis template): [CHK-2388] add ops for stream and for get all entries

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/redis/templatewrappers/RedisTemplateWrapper.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/redis/templatewrappers/RedisTemplateWrapper.java
@@ -165,6 +165,77 @@ public abstract class RedisTemplateWrapper<V> {
     }
 
     /**
+     * Write an event to the stream with the specified key trimming events before
+     * writing the new events so that stream has the wanted size
+     *
+     * @param streamKey  the stream key where send the event to
+     * @param event      the event to be sent
+     * @param streamSize the wanted length of the stream
+     * @return the {@link RecordId} associated to the written event
+     */
+    public RecordId writeEventToStreamTrimmingEvents(
+                                                     String streamKey,
+                                                     V event,
+                                                     long streamSize
+    ) {
+        if (streamSize < 0) {
+            throw new IllegalArgumentException("Invalid input %s events to trim, it must be >=0".formatted(streamSize));
+        }
+        redisTemplate.opsForStream().trim(streamKey, streamSize);
+        return redisTemplate
+                .opsForStream()
+                .add(
+                        ObjectRecord.create(
+                                streamKey,
+                                event
+                        )
+                );
+    }
+
+    /**
+     * Trim events from the stream with input key to the wanted size
+     *
+     * @param streamKey  the stream key from which trim events
+     * @param streamSize the wanted stream size
+     * @return the number or removed events from the stream
+     */
+    public Long trimEvents(
+                           String streamKey,
+                           long streamSize
+    ) {
+        return redisTemplate.opsForStream().trim(streamKey, streamSize);
+    }
+
+    /**
+     * Create a consumer group positioned at the latest event offset for the stream
+     * with input id
+     *
+     * @param streamKey the stream key for which create the group
+     * @param groupName the group name
+     * @return OK if operation was successful
+     */
+    public String createGroup(
+                              String streamKey,
+                              String groupName
+    ) {
+        return redisTemplate.opsForStream().createGroup(streamKey, groupName);
+    }
+
+    /**
+     * Destroy stream consumer group for the stream with input id
+     *
+     * @param streamKey the stream for which remove the group
+     * @param groupName the group name to be destroyed
+     * @return true iff the operation is completed successfully
+     */
+    public Boolean destroyGroup(
+                                String streamKey,
+                                String groupName
+    ) {
+        return redisTemplate.opsForStream().destroyGroup(streamKey, groupName);
+    }
+
+    /**
      * Get all the keys in keyspace
      *
      * @return a set populated with all the keys in keyspace

--- a/src/main/java/it/pagopa/ecommerce/commons/redis/templatewrappers/RedisTemplateWrapper.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/redis/templatewrappers/RedisTemplateWrapper.java
@@ -208,6 +208,22 @@ public abstract class RedisTemplateWrapper<V> {
     }
 
     /**
+     * Acknowledge input record ids for group inside streamKey stream
+     *
+     * @param streamKey the stream key
+     * @param groupId   the group id for which perform acknowledgment operation
+     * @param recordIds records for which perform ack operation
+     * @return the number of stream operations performed
+     */
+    public Long acknowledgeEvents(
+                                  String streamKey,
+                                  String groupId,
+                                  String... recordIds
+    ) {
+        return redisTemplate.opsForStream().acknowledge(streamKey, groupId, recordIds);
+    }
+
+    /**
      * Create a consumer group positioned at the latest event offset for the stream
      * with input id
      *

--- a/src/main/java/it/pagopa/ecommerce/commons/redis/templatewrappers/RedisTemplateWrapper.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/redis/templatewrappers/RedisTemplateWrapper.java
@@ -1,6 +1,7 @@
 package it.pagopa.ecommerce.commons.redis.templatewrappers;
 
 import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.lang.NonNull;
@@ -219,6 +220,23 @@ public abstract class RedisTemplateWrapper<V> {
                               String groupName
     ) {
         return redisTemplate.opsForStream().createGroup(streamKey, groupName);
+    }
+
+    /**
+     * Create a consumer group positioned at the latest event offset for the stream
+     * with input id
+     *
+     * @param streamKey  the stream key for which create the group
+     * @param groupName  the group name
+     * @param readOffset the offset from which start the receiver group
+     * @return OK if operation was successful
+     */
+    public String createGroup(
+                              String streamKey,
+                              String groupName,
+                              ReadOffset readOffset
+    ) {
+        return redisTemplate.opsForStream().createGroup(streamKey, readOffset, groupName);
     }
 
     /**

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/UniqueIdUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/UniqueIdUtils.java
@@ -3,8 +3,6 @@ package it.pagopa.ecommerce.commons.utils;
 import it.pagopa.ecommerce.commons.exceptions.UniqueIdGenerationException;
 import it.pagopa.ecommerce.commons.redis.templatewrappers.UniqueIdTemplateWrapper;
 import it.pagopa.ecommerce.commons.repositories.UniqueIdDocument;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 import java.security.SecureRandom;
@@ -13,7 +11,6 @@ import java.time.Duration;
 /**
  * This class generate unique identifier
  */
-@Component
 public class UniqueIdUtils {
     private final UniqueIdTemplateWrapper uniqueIdTemplateWrapper;
     private static final SecureRandom secureRandom = new SecureRandom();
@@ -28,7 +25,6 @@ public class UniqueIdUtils {
      * @param uniqueIdTemplateWrapper redis template wrapper used for save id into
      *                                cache
      */
-    @Autowired
     public UniqueIdUtils(UniqueIdTemplateWrapper uniqueIdTemplateWrapper) {
         this.uniqueIdTemplateWrapper = uniqueIdTemplateWrapper;
     }

--- a/src/test/java/it/pagopa/ecommerce/commons/redis/v1/templatewrappers/PaymentRequestInfoRedisTemplateWrapperTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/redis/v1/templatewrappers/PaymentRequestInfoRedisTemplateWrapperTest.java
@@ -248,6 +248,22 @@ class PaymentRequestInfoRedisTemplateWrapperTest {
     }
 
     @Test
+    void shouldTrimEventsSuccessfully() {
+        // assertions
+        String streamKey = "streamKey";
+        int streamSize = 0;
+        Mockito.when(redisTemplate.opsForStream()).thenReturn((StreamOperations) streamOperations);
+        Mockito.when(streamOperations.trim(streamKey, streamSize)).thenReturn(0L);
+        // test
+        paymentRequestInfoRedisTemplateWrapper
+                .trimEvents(streamKey, streamSize);
+
+        // assertions
+        Mockito.verify(streamOperations, Mockito.times(1))
+                .trim(streamKey, streamSize);
+    }
+
+    @Test
     void shouldThrowExceptionWritingEventToStreamWithInvalidStreamSize() {
         // assertions
         String streamKey = "streamKey";

--- a/src/test/java/it/pagopa/ecommerce/commons/redis/v1/templatewrappers/PaymentRequestInfoRedisTemplateWrapperTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/redis/v1/templatewrappers/PaymentRequestInfoRedisTemplateWrapperTest.java
@@ -6,6 +6,7 @@ import it.pagopa.ecommerce.commons.v1.TransactionTestUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StreamOperations;
@@ -302,6 +303,23 @@ class PaymentRequestInfoRedisTemplateWrapperTest {
         // assertions
         Mockito.verify(streamOperations, Mockito.times(1))
                 .createGroup(streamKey, groupName);
+        assertEquals("OK", outcome);
+    }
+
+    @Test
+    void shouldCreateStreamEventGroupSuccessfullyWithCustomReadOffset() {
+        // assertions
+        String streamKey = "streamKey";
+        String groupName = "groupName";
+        ReadOffset offset = ReadOffset.from("0-0");
+        Mockito.when(redisTemplate.opsForStream()).thenReturn((StreamOperations) streamOperations);
+        Mockito.when(streamOperations.createGroup(streamKey, offset, groupName)).thenReturn("OK");
+        // test
+        String outcome = paymentRequestInfoRedisTemplateWrapper.createGroup(streamKey, groupName, offset);
+
+        // assertions
+        Mockito.verify(streamOperations, Mockito.times(1))
+                .createGroup(streamKey, offset, groupName);
         assertEquals("OK", outcome);
     }
 

--- a/src/test/java/it/pagopa/ecommerce/commons/redis/v1/templatewrappers/PaymentRequestInfoRedisTemplateWrapperTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/redis/v1/templatewrappers/PaymentRequestInfoRedisTemplateWrapperTest.java
@@ -339,4 +339,25 @@ class PaymentRequestInfoRedisTemplateWrapperTest {
         assertEquals(Boolean.TRUE, outcome);
     }
 
+    @Test
+    void shouldAcknowledgeEventSuccessfully() {
+        // assertions
+        String streamKey = "streamKey";
+        String groupId = "group";
+        String[] ids = {
+                "id1",
+                "id2"
+        };
+        int streamSize = 0;
+        Mockito.when(redisTemplate.opsForStream()).thenReturn((StreamOperations) streamOperations);
+        Mockito.when(streamOperations.acknowledge(streamKey, groupId, ids)).thenReturn(0L);
+        // test
+        paymentRequestInfoRedisTemplateWrapper
+                .acknowledgeEvents(streamKey, groupId, ids);
+
+        // assertions
+        Mockito.verify(streamOperations, Mockito.times(1))
+                .acknowledge(streamKey, groupId, ids);
+    }
+
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add redis template operations for:
- retrieve all keys and entries in keyspace
- write event to event stream with/without events trimming operation
- create/destroy event stream consumer group

<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed in order to perform stream operations and retrieve all entries from redis
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests + tests with eCommerce locals
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.