### PR TITLE
fix: set api key into Node Forwarder api call

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/client/NodeForwarderClient.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/client/NodeForwarderClient.java
@@ -43,6 +43,11 @@ public class NodeForwarderClient<T, R> {
             .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 
     /**
+     * Node forwarder api key header
+     */
+    private static final String API_KEY_REQUEST_HEADER_KEY = "Ocp-Apim-Subscription-Key";
+
+    /**
      * Header that contains unique request id
      */
     private static final String REQUEST_ID_HEADER_VALUE = "X-Request-Id";
@@ -117,7 +122,9 @@ public class NodeForwarderClient<T, R> {
         WebClient webClient = ApiClient.buildWebClientBuilder()
                 .clientConnector(
                         new ReactorClientHttpConnector(httpClient)
-                ).baseUrl(backendUrl).build();
+                ).baseUrl(backendUrl)
+                .defaultHeader(API_KEY_REQUEST_HEADER_KEY, apiKey)
+                .build();
 
         ApiClient apiClient = new ApiClient(
                 webClient

--- a/src/test/java/it/pagopa/ecommerce/commons/client/NodeForwarderClientTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/client/NodeForwarderClientTest.java
@@ -7,8 +7,8 @@ import okhttp3.Headers;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.ResponseEntity;
@@ -47,16 +47,16 @@ class NodeForwarderClientTest {
 
     private static MockWebServer mockWebServer;
 
-    @BeforeAll
-    public static void beforeAll() throws IOException {
+    @BeforeEach
+    public void beforeAll() throws IOException {
         mockWebServer = new MockWebServer();
         mockWebServer.start(8080);
         System.out.printf("Mock web server listening on %s:%s%n", mockWebServer.getHostName(), mockWebServer.getPort());
 
     }
 
-    @AfterAll
-    public static void afterAll() throws IOException {
+    @AfterEach
+    public void afterAll() throws IOException {
         mockWebServer.shutdown();
         System.out.println("Mock web server stopped");
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add explicit default header for Node Forwarder client setting api key as `Ocp-Apim-Subscription-Key` header
<!--- Describe your changes in detail -->

#### Motivation and Context
This fix is required since specs does not provide authorization header for proxy api calls making api call being sent without api key header
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.