### PR TITLE
[CHK-2850] fix(tracing): use `ContextPropagationOperator` to propagate otel context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,12 @@
             <artifactId>opentelemetry-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-reactor-3.1</artifactId>
+            <version>2.4.0-alpha</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
             <version>0.11.4</version>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
 * use `ContextPropagationOperator` to propagate otel context

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This change fixes a context propagation bug when creating new spans within a reactive chain.
This bug meant that when creating a new `Span` linked with a remote tracing context the local tracing context would be lost, leading to missing child spans.

**Before**
![immagine](https://github.com/pagopa/pagopa-ecommerce-commons/assets/8624484/6bf33775-c5fc-4431-bb3b-24424f6b46e2)

**After**
![immagine](https://github.com/pagopa/pagopa-ecommerce-commons/assets/8624484/03498efa-a507-4156-ade4-8cf012b9aa11)


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.