### PR TITLE
[CHK2861] fix(jwt-token): add userId in possible claims of jwt token

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/domain/Claims.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/Claims.java
@@ -3,6 +3,7 @@ package it.pagopa.ecommerce.commons.domain;
 import it.pagopa.ecommerce.commons.annotations.ValueObject;
 
 import javax.annotation.Nullable;
+import java.util.UUID;
 
 /**
  * <p>
@@ -12,11 +13,14 @@ import javax.annotation.Nullable;
  * @param transactionId   transactionId
  * @param orderId         orderId
  * @param paymentMethodId payment methodId
+ * @param userId          the userId identified by the wallet token that
+ *                        performs the payment
  */
 @ValueObject
 public record Claims(
         @Nullable TransactionId transactionId,
         @Nullable String orderId,
-        @Nullable String paymentMethodId
+        @Nullable String paymentMethodId,
+        @Nullable String userId
 ) {
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/Claims.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/Claims.java
@@ -21,6 +21,6 @@ public record Claims(
         @Nullable TransactionId transactionId,
         @Nullable String orderId,
         @Nullable String paymentMethodId,
-        @Nullable String userId
+        @Nullable UUID userId
 ) {
 }

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/JwtTokenUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/JwtTokenUtils.java
@@ -38,6 +38,10 @@ public class JwtTokenUtils {
      * The claim payment methodId
      */
     public static final String PAYMENT_METHOD_ID_CLAIM = "paymentMethodId";
+    /**
+     * The claim userId
+     */
+    public static final String USER_ID_CLAIM = "userId";
 
     /**
      * This method generates a jwt with specific claim
@@ -71,6 +75,9 @@ public class JwtTokenUtils {
             }
             if (claims.paymentMethodId() != null) {
                 jwtBuilder.claim(PAYMENT_METHOD_ID_CLAIM, claims.paymentMethodId()); // claim paymentMethodId
+            }
+            if (claims.userId() != null) {
+                jwtBuilder.claim(USER_ID_CLAIM, claims.userId().toString()); // claim paymentMethodId
             }
             return Either.right(jwtBuilder.compact());
         } catch (JwtException e) {

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/JwtTokenUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/JwtTokenUtils.java
@@ -77,7 +77,7 @@ public class JwtTokenUtils {
                 jwtBuilder.claim(PAYMENT_METHOD_ID_CLAIM, claims.paymentMethodId()); // claim paymentMethodId
             }
             if (claims.userId() != null) {
-                jwtBuilder.claim(USER_ID_CLAIM, claims.userId().toString()); // claim paymentMethodId
+                jwtBuilder.claim(USER_ID_CLAIM, claims.userId().toString()); // claim userId
             }
             return Either.right(jwtBuilder.compact());
         } catch (JwtException e) {

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/JwtTokenUtilsTests.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/JwtTokenUtilsTests.java
@@ -124,7 +124,7 @@ class JwtTokenUtilsTests {
 
     @Test
     void shouldGenerateValidJwtTokenWithOnlyUserId() {
-        String userId = UUID.randomUUID().toString();
+        UUID userId = UUID.randomUUID();
         it.pagopa.ecommerce.commons.domain.Claims jwtClaims = new it.pagopa.ecommerce.commons.domain.Claims(
                 null,
                 null,
@@ -139,7 +139,7 @@ class JwtTokenUtilsTests {
                 () -> Jwts.parserBuilder().setSigningKey(jwtSecretKey).build().parseClaimsJws(generatedToken.get())
                         .getBody()
         );
-        assertEquals(userId, claims.get(JwtTokenUtils.USER_ID_CLAIM, String.class));
+        assertEquals(userId.toString(), claims.get(JwtTokenUtils.USER_ID_CLAIM, String.class));
         assertNull(claims.get(JwtTokenUtils.ORDER_ID_CLAIM, String.class));
         assertNotNull(claims.getId());
         assertNotNull(claims.getIssuedAt());
@@ -153,7 +153,7 @@ class JwtTokenUtilsTests {
     @Test
     void shouldGenerateValidJwtTokenWithTransactionIdAndUserId() {
         TransactionId transactionId = new TransactionId(UUID.randomUUID());
-        String userId = UUID.randomUUID().toString();
+        UUID userId = UUID.randomUUID();
         it.pagopa.ecommerce.commons.domain.Claims jwtClaims = new it.pagopa.ecommerce.commons.domain.Claims(
                 transactionId,
                 null,
@@ -169,7 +169,7 @@ class JwtTokenUtilsTests {
                         .getBody()
         );
         assertEquals(transactionId.value(), claims.get(JwtTokenUtils.TRANSACTION_ID_CLAIM, String.class));
-        assertEquals(userId, claims.get(JwtTokenUtils.USER_ID_CLAIM, String.class));
+        assertEquals(userId.toString(), claims.get(JwtTokenUtils.USER_ID_CLAIM, String.class));
         assertNull(claims.get(JwtTokenUtils.ORDER_ID_CLAIM, String.class));
         assertNull(claims.get(JwtTokenUtils.PAYMENT_METHOD_ID_CLAIM, String.class));
         assertNotNull(claims.getId());
@@ -186,7 +186,7 @@ class JwtTokenUtilsTests {
         TransactionId transactionId = new TransactionId(UUID.randomUUID());
         String orderId = UUID.randomUUID().toString();
         String paymentMethodId = UUID.randomUUID().toString();
-        String userId = UUID.randomUUID().toString();
+        UUID userId = UUID.randomUUID();
         it.pagopa.ecommerce.commons.domain.Claims jwtClaims = new it.pagopa.ecommerce.commons.domain.Claims(
                 transactionId,
                 orderId,
@@ -205,7 +205,7 @@ class JwtTokenUtilsTests {
         assertEquals(transactionId.value(), claims.get(JwtTokenUtils.TRANSACTION_ID_CLAIM, String.class));
         assertEquals(orderId, claims.get(JwtTokenUtils.ORDER_ID_CLAIM, String.class));
         assertEquals(paymentMethodId, claims.get(JwtTokenUtils.PAYMENT_METHOD_ID_CLAIM, String.class));
-        assertEquals(userId, claims.get(JwtTokenUtils.USER_ID_CLAIM, String.class));
+        assertEquals(userId.toString(), claims.get(JwtTokenUtils.USER_ID_CLAIM, String.class));
         assertNotNull(claims.getId());
         assertNotNull(claims.getIssuedAt());
         assertNotNull(claims.getExpiration());
@@ -220,7 +220,7 @@ class JwtTokenUtilsTests {
         TransactionId transactionId = new TransactionId(UUID.randomUUID());
         String orderId = UUID.randomUUID().toString();
         String paymentMethodId = UUID.randomUUID().toString();
-        String userId = UUID.randomUUID().toString();
+        UUID userId = UUID.randomUUID();
         it.pagopa.ecommerce.commons.domain.Claims jwtClaims = new it.pagopa.ecommerce.commons.domain.Claims(
                 transactionId,
                 orderId,


### PR DESCRIPTION
Since we introduced `userId` validation for `ecommerce-for-io` api group, we need to add the userId to the jwt token claims. This PR introduce this extension for Claims

#### List of Changes

Add userId as possible claim for jwt token

#### Motivation and Context

Enforce `ecommerce-for-io` api group security by checking `userId` value

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.