### PR TITLE
feat: add optional idBundle field into auth requested event

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v2/TransactionAuthorizationRequestData.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v2/TransactionAuthorizationRequestData.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 /**
@@ -31,6 +32,13 @@ public class TransactionAuthorizationRequestData {
     private String paymentMethodDescription;
     @NotNull
     private TransactionGatewayAuthorizationRequestedData transactionGatewayAuthorizationRequestedData;
+
+    /**
+     * Bundle unique id, set as nullable for backward compatibility with previously
+     * written events
+     */
+    @Nullable
+    private String idBundle;
 
     /**
      * Enumeration of different PaymentGateway

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v2/Transaction.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v2/Transaction.java
@@ -84,4 +84,5 @@ public sealed interface Transaction permits EmptyTransaction,TransactionActivate
      * @return a new transaction object with the event applied
      */
     Transaction applyEvent(Object event);
+
 }

--- a/src/test/java/it/pagopa/ecommerce/commons/documents/v2/serialization/TransactionEventTypeResolverTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/documents/v2/serialization/TransactionEventTypeResolverTest.java
@@ -1739,7 +1739,7 @@ class TransactionEventTypeResolverTest {
     }
 
     @Test
-    void canRoundTripQueueAuthorizationRequestedEventSerializationWithNullIdBundle() {
+    void shouldDeserializeAuthorizationRequestedEventWithNullIdBundle() {
         String serializedEvent = """
                 {
                         "event": {
@@ -1775,7 +1775,6 @@ class TransactionEventTypeResolverTest {
                                         }
                                     }
                                 },
-                                "idBundle": null,
                                 "pspOnUs": false
                             },
                             "eventCode": "TRANSACTION_AUTHORIZATION_REQUESTED_EVENT"

--- a/src/test/java/it/pagopa/ecommerce/commons/v2/TransactionTestUtils.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/v2/TransactionTestUtils.java
@@ -122,6 +122,8 @@ public class TransactionTestUtils {
     public static final String COMPANY_NAME = "companyName";
     public static final String CREDITOR_REFERENCE_ID = "222222222222";
 
+    public static final String ID_BUNDLE = "idBundle";
+
     @Nonnull
     public static TransactionActivatedEvent transactionActivateEvent() {
         return transactionActivateEvent(new EmptyTransactionGatewayActivationData());
@@ -329,7 +331,8 @@ public class TransactionTestUtils {
                         AUTHORIZATION_REQUEST_ID,
                         paymentGateway,
                         PAYMENT_METHOD_DESCRIPTION,
-                        transactionGatewayAuthorizationRequestedData
+                        transactionGatewayAuthorizationRequestedData,
+                        ID_BUNDLE
                 )
         );
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add optional `idBundle` field into v2 authorization requested event
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to trace GEC idBundle into authorization requested event so that this field could be propagated to the Nodo into Close payment request.
FIeld have been marked as nullable in order to be backward compatible with previously written events where this field is not written
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.