### PR TITLE
[PPABV-61] Add utils class to get paymentEndToEndId from Npg getOrder

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/utils/NpgClientUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/NpgClientUtils.java
@@ -7,6 +7,14 @@ import it.pagopa.ecommerce.commons.generated.npg.v1.dto.OperationDto;
  * Utility class for handling NPG client operations.
  */
 public class NpgClientUtils {
+
+    /**
+     * Create NpgClientUtils object.
+     */
+    private NpgClientUtils() {
+        throw new IllegalStateException("Utility EuroUtils class");
+    }
+
     /**
      * Enum representing the mapping between payment circuits and their respective
      * field names for the `paymentEndToEndId` in the additional data map.

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/NpgClientUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/NpgClientUtils.java
@@ -1,0 +1,82 @@
+package it.pagopa.ecommerce.commons.utils;
+
+import it.pagopa.ecommerce.commons.client.NpgClient;
+import it.pagopa.ecommerce.commons.generated.npg.v1.dto.OperationDto;
+
+/**
+ * Utility class for handling NPG client operations.
+ */
+public class NpgClientUtils {
+    /**
+     * Enum representing the mapping between payment circuits and their respective
+     * field names for the `paymentEndToEndId` in the additional data map.
+     */
+    public enum EndToEndId {
+        /**
+         * Represents the Bancomat Pay circuit. The corresponding field name in the
+         * additional data map is `bpayEndToEndId`.
+         */
+        BANCOMAT_PAY("bpayEndToEndId"),
+        /**
+         * Represents the MyBank circuit. The corresponding field name in the additional
+         * data map is `myBankEndToEndId`.
+         */
+        MYBANK("myBankEndToEndId");
+
+        /**
+         * The field name in the additional data map associated with this payment
+         * circuit.
+         */
+        public final String value;
+
+        /**
+         * Constructor for the EndToEndId enum.
+         *
+         * @param value The field name in the additional data map corresponding to the
+         *              payment circuit.
+         */
+        EndToEndId(String value) {
+            this.value = value;
+        }
+    }
+
+    /**
+     * Retrieves the `paymentEndToEndId` value for the specified payment circuit
+     * from the NPG `getOrder` response.
+     *
+     * @param operationDto The response object from the NPG `getOrder` call. This
+     *                     object contains details about the payment operation,
+     *                     including the payment circuit and additional data.
+     * @return The `paymentEndToEndId` corresponding to the payment circuit, or
+     *         {@code null} if the value cannot be determined.
+     *
+     *         <p>
+     *         For supported payment circuits:
+     *         <ul>
+     *         <li>If the circuit is Bancomat Pay, the value of `bpayEndToEndId`
+     *         from the additional data map is returned.</li>
+     *         <li>If the circuit is MyBank, the value of `myBankEndToEndId` from
+     *         the additional data map is returned.</li>
+     *         </ul>
+     *         If the circuit is unsupported or additional data is unavailable, the
+     *         `paymentEndToEndId` field from the `operationDto` object is used as a
+     *         fallback.
+     */
+    public static String getPaymentEndToEndId(OperationDto operationDto) {
+        if (operationDto == null || operationDto.getPaymentCircuit() == null)
+            return null;
+
+        if (operationDto.getPaymentCircuit().equals(NpgClient.PaymentMethod.BANCOMATPAY.serviceName)) {
+            // for bancomatPay we expect an `bpayEndToEndId` entry into additional data map
+            // to be used as
+            // the paymentEndToEndId
+            return operationDto.getAdditionalData() == null ? operationDto.getPaymentEndToEndId()
+                    : (String) operationDto.getAdditionalData().get(EndToEndId.BANCOMAT_PAY.value);
+        } else if (operationDto.getPaymentCircuit().equals(NpgClient.PaymentMethod.MYBANK.serviceName)) {
+            return operationDto.getAdditionalData() == null ? operationDto.getPaymentEndToEndId()
+                    : (String) operationDto.getAdditionalData().get(EndToEndId.MYBANK.value);
+        } else {
+            return operationDto.getPaymentEndToEndId();
+        }
+    }
+}

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/NpgClientUtilsTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/NpgClientUtilsTest.java
@@ -1,0 +1,78 @@
+package it.pagopa.ecommerce.commons.utils;
+
+import it.pagopa.ecommerce.commons.client.NpgClient;
+import it.pagopa.ecommerce.commons.generated.npg.v1.dto.OperationDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NpgClientUtilsTest {
+
+    private static Stream<Arguments> paymentEndToEndIdTestCase() {
+        return Stream.of(
+                Arguments.of(
+                        NpgClient.PaymentMethod.BANCOMATPAY,
+                        Map.of(NpgClientUtils.EndToEndId.BANCOMAT_PAY.value, "bpayEndToEndId"),
+                        "bpayEndToEndId"
+                ),
+                Arguments.of(
+                        NpgClient.PaymentMethod.BANCOMATPAY,
+                        null,
+                        "paymentEndToEndId"
+                ),
+                Arguments.of(
+                        NpgClient.PaymentMethod.MYBANK,
+                        Map.of(NpgClientUtils.EndToEndId.MYBANK.value, "myBankEndToEndId"),
+                        "myBankEndToEndId"
+                ),
+                Arguments.of(
+                        NpgClient.PaymentMethod.MYBANK,
+                        null,
+                        "paymentEndToEndId"
+                ),
+                Arguments.of(
+                        NpgClient.PaymentMethod.CARDS,
+                        Map.of(),
+                        "paymentEndToEndId"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("paymentEndToEndIdTestCase")
+    public void shouldGetPaymentEndToEndId(
+                                           NpgClient.PaymentMethod paymentMethod,
+                                           Map<String, Object> additionalData,
+                                           String expectedPaymentId
+    ) {
+        OperationDto operationDto = mock(OperationDto.class);
+        if (additionalData == null || additionalData.isEmpty())
+            when(operationDto.getPaymentEndToEndId()).thenReturn(expectedPaymentId);
+
+        when(operationDto.getPaymentCircuit()).thenReturn(paymentMethod.serviceName);
+        when(operationDto.getAdditionalData()).thenReturn(additionalData);
+        assertEquals(expectedPaymentId, NpgClientUtils.getPaymentEndToEndId(operationDto));
+
+    }
+
+    @Test
+    public void shouldReturnNullForGetPaymentEndToEndIdWithOperationNull() {
+        assertNull(NpgClientUtils.getPaymentEndToEndId(null));
+    }
+
+    @Test
+    public void shouldReturnNullForGetPaymentEndToEndIdWithPaymentCircuitNull() {
+        OperationDto operationDto = mock(OperationDto.class);
+        when(operationDto.getPaymentCircuit()).thenReturn(null);
+        assertNull(NpgClientUtils.getPaymentEndToEndId(operationDto));
+    }
+}

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/NpgClientUtilsTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/NpgClientUtilsTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class NpgClientUtilsTest {
+class NpgClientUtilsTest {
 
     private static Stream<Arguments> paymentEndToEndIdTestCase() {
         return Stream.of(
@@ -53,10 +53,10 @@ public class NpgClientUtilsTest {
 
     @ParameterizedTest
     @MethodSource("paymentEndToEndIdTestCase")
-    public void shouldGetPaymentEndToEndId(
-                                           NpgClient.PaymentMethod paymentMethod,
-                                           Map<String, Object> additionalData,
-                                           String expectedPaymentId
+    void shouldGetPaymentEndToEndId(
+                                    NpgClient.PaymentMethod paymentMethod,
+                                    Map<String, Object> additionalData,
+                                    String expectedPaymentId
     ) {
         OperationDto operationDto = mock(OperationDto.class);
         if (additionalData == null || additionalData.isEmpty())
@@ -69,12 +69,12 @@ public class NpgClientUtilsTest {
     }
 
     @Test
-    public void shouldReturnNullForGetPaymentEndToEndIdWithOperationNull() {
+    void shouldReturnNullForGetPaymentEndToEndIdWithOperationNull() {
         assertNull(getPaymentEndToEndId(null));
     }
 
     @Test
-    public void shouldReturnNullForGetPaymentEndToEndIdWithPaymentCircuitNull() {
+    void shouldReturnNullForGetPaymentEndToEndIdWithPaymentCircuitNull() {
         OperationDto operationDto = mock(OperationDto.class);
         when(operationDto.getPaymentCircuit()).thenReturn(null);
         assertNull(getPaymentEndToEndId(operationDto));

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/NpgClientUtilsTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/NpgClientUtilsTest.java
@@ -7,11 +7,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static it.pagopa.ecommerce.commons.utils.NpgClientUtils.getPaymentEndToEndId;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -60,19 +64,28 @@ public class NpgClientUtilsTest {
 
         when(operationDto.getPaymentCircuit()).thenReturn(paymentMethod.serviceName);
         when(operationDto.getAdditionalData()).thenReturn(additionalData);
-        assertEquals(expectedPaymentId, NpgClientUtils.getPaymentEndToEndId(operationDto));
+        assertEquals(expectedPaymentId, getPaymentEndToEndId(operationDto));
 
     }
 
     @Test
     public void shouldReturnNullForGetPaymentEndToEndIdWithOperationNull() {
-        assertNull(NpgClientUtils.getPaymentEndToEndId(null));
+        assertNull(getPaymentEndToEndId(null));
     }
 
     @Test
     public void shouldReturnNullForGetPaymentEndToEndIdWithPaymentCircuitNull() {
         OperationDto operationDto = mock(OperationDto.class);
         when(operationDto.getPaymentCircuit()).thenReturn(null);
-        assertNull(NpgClientUtils.getPaymentEndToEndId(operationDto));
+        assertNull(getPaymentEndToEndId(operationDto));
+    }
+
+    @Test
+    void testConstructorIsPrivate()
+            throws NoSuchMethodException {
+        Constructor<NpgClientUtils> constructor = NpgClientUtils.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        assertThrows(InvocationTargetException.class, constructor::newInstance);
+        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Add utils class to get paymentEndToEndId from Npg getOrder
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR centralizes the method for retrieving the paymentEndToEndId from the NPG getOrder response, enabling it to be reused across multiple services, including the event-dispatcher-service and the transaction-scheduler-service.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
JUnit Test
#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.