### PR TITLE
feat(cdc): [CHK-4348] add field to keep transactions-view order

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/documents/v2/Transaction.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/documents/v2/Transaction.java
@@ -68,6 +68,13 @@ public class Transaction extends BaseTransactionView {
     private String pspId;
 
     /**
+     * Timestamp of the last processed CDC event. Used by CDC service to handle
+     * out-of-order events and ensure status updates are applied chronologically.
+     */
+    @Nullable
+    private Long lastProcessedEventAt;
+
+    /**
      * Enumeration of transaction client initiators
      */
     public enum ClientId {
@@ -126,18 +133,20 @@ public class Transaction extends BaseTransactionView {
      * Primary persistence constructor. Warning java:S107 - Methods should not have
      * too many parameters
      *
-     * @param transactionId   transaction unique id
-     * @param paymentNotices  notice code list
-     * @param email           user email where the payment receipt will be sent to
-     * @param status          transaction status
-     * @param clientId        the client identifier
-     * @param feeTotal        transaction total fee
-     * @param creationDate    transaction creation date
-     * @param idCart          the ec cart id
-     * @param rrn             the rrn information
-     * @param userId          the user unique id
-     * @param paymentTypeCode the payment type code defined in Node domain
-     * @param pspId           the psp id
+     * @param transactionId        transaction unique id
+     * @param paymentNotices       notice code list
+     * @param email                user email where the payment receipt will be sent
+     *                             to
+     * @param status               transaction status
+     * @param clientId             the client identifier
+     * @param feeTotal             transaction total fee
+     * @param creationDate         transaction creation date
+     * @param idCart               the ec cart id
+     * @param rrn                  the rrn information
+     * @param userId               the user unique id
+     * @param paymentTypeCode      the payment type code defined in Node domain
+     * @param pspId                the psp id
+     * @param lastProcessedEventAt UNIX timestamp of last processed CDC event
      */
     /*
      * @formatter:off
@@ -166,7 +175,8 @@ public class Transaction extends BaseTransactionView {
             @Nullable String rrn,
             @Nullable String userId,
             @Nullable String paymentTypeCode,
-            @Nullable String pspId
+            @Nullable String pspId,
+            @Nullable Long lastProcessedEventAt
     ) {
         super(transactionId);
         this.email = email;
@@ -180,6 +190,7 @@ public class Transaction extends BaseTransactionView {
         this.userId = userId;
         this.paymentTypeCode = paymentTypeCode;
         this.pspId = pspId;
+        this.lastProcessedEventAt = lastProcessedEventAt;
     }
 
     /**
@@ -201,7 +212,8 @@ public class Transaction extends BaseTransactionView {
                 null,
                 transaction.getTransactionActivatedData().getUserId(),
                 null,
-                null
+                null,
+                null // lastProcessedEventAt - will be set by CDC service
         );
     }
 

--- a/src/test/java/it/pagopa/ecommerce/commons/documents/v2/TransactionDocumentTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/documents/v2/TransactionDocumentTest.java
@@ -45,6 +45,7 @@ class TransactionDocumentTest {
         assertEquals(TransactionTestUtils.AMOUNT, transaction.getPaymentNotices().get(0).getAmount());
         assertEquals(TransactionTestUtils.TRANSACTION_ID, transaction.getTransactionId());
         assertEquals(transactionStatus, transaction.getStatus());
+        assertEquals(TransactionTestUtils.LAST_PROCESSED_EVENT_AT, transaction.getLastProcessedEventAt());
 
         assertNotEquals(transaction, differentTransaction);
         assertEquals(transaction.hashCode(), sameTransaction.hashCode());
@@ -76,6 +77,7 @@ class TransactionDocumentTest {
         );
         assertEquals(ZonedDateTime.parse(transactionDocument.getCreationDate()), transaction.getCreationDate());
         assertEquals(transactionDocument.getStatus(), transaction.getStatus());
+        assertNull(transactionDocument.getLastProcessedEventAt());
     }
 
     @Test

--- a/src/test/java/it/pagopa/ecommerce/commons/v2/TransactionTestUtils.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/v2/TransactionTestUtils.java
@@ -98,6 +98,8 @@ public class TransactionTestUtils {
     public static final String DUE_DATE = "1900-01-01";
     public static final String IDEMPOTENCY_KEY = "00000000000_AABBCCDDEE";
 
+    public static final Long LAST_PROCESSED_EVENT_AT = System.currentTimeMillis();
+
     public static final int PAYMENT_TOKEN_VALIDITY_TIME_SEC = 900;
 
     public static final String NPG_ORDER_ID = "npgOrderId";
@@ -729,7 +731,8 @@ public class TransactionTestUtils {
                 RRN,
                 USER_ID,
                 null,
-                null
+                null,
+                LAST_PROCESSED_EVENT_AT
         );
     }
 


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- added a new field `lastProcessedEventAt` to the transaction view collection

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The new field is used to determine if an incoming event is newer than the last processed event, to support CDC event ordering and prevent out-of-order event processing.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- unit tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.