### PR TITLE
fix(reduce): handle closure synthetic on expired event

### DIFF
--- a/specs/v2/state_machine.js
+++ b/specs/v2/state_machine.js
@@ -200,6 +200,12 @@ createMachine(
           },
           REFUND_ERROR: {
             target: "REFUND_ERROR"
+          },
+          CLOSURE_SYNTHETIC: {
+            target: "CLOSED"
+          },
+          ADD_USER_RECEIPT: {
+            target: "NOTIFICATION_REQUESTED"
           }
         },
       },

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v2/Transaction.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v2/Transaction.java
@@ -43,18 +43,22 @@ import it.pagopa.ecommerce.commons.domain.v2.pojos.BaseTransaction;
  *              ▼                                                  │
  *     AUTHORIZATION_COMPLETED                                     │───► REFUND_REQUESTED ───► REFUND_ERROR / REFUNDED
  *              │                                                  │
- *              │                                                  │
- *              ▼                                                  │
- *       CLOSURE_REQUESTED                                         │
- *              │                                                  │
- *              ├──────────► CLOSURE_ERROR──────┐                  │
- *              ├──────────► EXPIRED ───────────┼──────────────────┚
- *              │                               │
- *              │                               │
- *              ──────────► UNAUTHORIZED        │
- *              │                               │
- *              ▼                               │
- *            CLOSED ───────────────────────────┘
+ *              │                                                  │──────► ┐
+ *              ▼                                                  │        │
+ *       CLOSURE_REQUESTED                                         │───► ┐  │
+ *              │                                                  │     │  │
+ *              ├──────────► CLOSURE_ERROR──────┐                  │     │  │
+ *              ├──────────► EXPIRED ───────────┼──────────────────┚     │  │
+ *              │                               │                        │  │
+ *              │                               │                        │  │
+ *              ──────────► UNAUTHORIZED        │                        │  │
+ *              │                               │                        │  │
+ *              ▼                               │                        │  │
+ *            CLOSED ◀──────────────────────────┘────────────────────────┘  │
+ *              │                                                           │
+ *              │                                                           │
+ *              ▼                                                           │
+ *     NOTIFICATION_REQUESTED ◀─────────────────────────────────────────────┘
  *              │
  *              ▼
  *    NOTIFIED OK / NOTIFIED KO

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v2/TransactionExpired.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v2/TransactionExpired.java
@@ -6,6 +6,7 @@ import it.pagopa.ecommerce.commons.documents.v2.TransactionRefundRequestedEvent;
 import it.pagopa.ecommerce.commons.documents.v2.TransactionUserReceiptRequestedEvent;
 import it.pagopa.ecommerce.commons.domain.v2.pojos.BaseTransactionClosed;
 import it.pagopa.ecommerce.commons.domain.v2.pojos.BaseTransactionExpired;
+import it.pagopa.ecommerce.commons.domain.v2.pojos.BaseTransactionWithClosureRequested;
 import it.pagopa.ecommerce.commons.domain.v2.pojos.BaseTransactionWithRequestedAuthorization;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
 import lombok.EqualsAndHashCode;
@@ -19,6 +20,10 @@ import lombok.ToString;
  * <ul>
  * <li>{@link TransactionRefundRequestedEvent} -->
  * {@link TransactionWithRefundRequested}</li>
+ * <li>{@link TransactionClosureSyntheticEvent} -->
+ * {@link TransactionClosed}</li>
+ * <li>{@link TransactionUserReceiptRequestedEvent} -->
+ * {@link TransactionWithRequestedUserReceipt}</li>
  * </ul>
  * Any other event than the above ones will be discarded.
  *
@@ -59,18 +64,22 @@ public final class TransactionExpired extends BaseTransactionExpired implements 
             );
         }
         /*
-         * in case of closure synthetic event the transaction will remain in EXPIRED
-         * status. the transaction at previous state aggregate is recalculated applying
-         * the closure synthetic event to effectively recalculate aggregate. This logic
-         * reflects the fact that a transaction can recover from EXPIRED status with an
-         * addUserReceipt request from Nodo and should handle closed transactions coming
-         * from both close event and synthetic one but the closure event itself.
+         * transaction with closure error, in case of expiration create two distinct
+         * aggregates: - TransactionExpired -> if closure error comes from the state
+         * machine flow where an authorization was requested -
+         * TransactionCancellationExpired -> if closure error comes from the state
+         * machine flow where the user cancel the transaction (no authorization was
+         * requested).
+         *
+         * In the first case the TransactionExpired aggregate
+         * "transactionAtPreviousStep" is valued with the
+         * BaseTransactionWithClosureRequested one so the below check cover both
+         * CLOSURE_REQUESTED and CLOSURE_ERROR transaction statuses
          */
-        if (event instanceof TransactionClosureSyntheticEvent transactionClosureSyntheticEvent) {
-            BaseTransactionWithRequestedAuthorization transactionAtPreviousState = this.getTransactionAtPreviousState();
-            BaseTransactionWithRequestedAuthorization recalculatedBaseTransaction = (BaseTransactionWithRequestedAuthorization) ((Transaction) transactionAtPreviousState)
-                    .applyEvent(transactionClosureSyntheticEvent);
-            return new TransactionExpired(recalculatedBaseTransaction, this.event);
+        if (event instanceof TransactionClosureSyntheticEvent transactionClosureSyntheticEvent
+                && getTransactionAtPreviousState()instanceof BaseTransactionWithClosureRequested txWithClosureRequested
+                && txWithClosureRequested.wasTransactionAuthorized()) {
+            return new TransactionClosed(txWithClosureRequested, transactionClosureSyntheticEvent);
         }
 
         if (event instanceof TransactionUserReceiptRequestedEvent transactionUserReceiptRequestedEvent &&

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v2/TransactionExpired.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v2/TransactionExpired.java
@@ -33,10 +33,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString
 public final class TransactionExpired extends BaseTransactionExpired implements Transaction {
-    /**
-     * The transaction expired event instance, used to perform re-aggregation
-     */
-    private final TransactionExpiredEvent event;
 
     /**
      * Primary constructor
@@ -49,7 +45,6 @@ public final class TransactionExpired extends BaseTransactionExpired implements 
             TransactionExpiredEvent event
     ) {
         super(baseTransaction, event.getData());
-        this.event = event;
     }
 
     /**

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v2/TransactionExpired.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v2/TransactionExpired.java
@@ -1,5 +1,6 @@
 package it.pagopa.ecommerce.commons.domain.v2;
 
+import it.pagopa.ecommerce.commons.documents.v2.TransactionClosureSyntheticEvent;
 import it.pagopa.ecommerce.commons.documents.v2.TransactionExpiredEvent;
 import it.pagopa.ecommerce.commons.documents.v2.TransactionRefundRequestedEvent;
 import it.pagopa.ecommerce.commons.documents.v2.TransactionUserReceiptRequestedEvent;
@@ -27,6 +28,10 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString
 public final class TransactionExpired extends BaseTransactionExpired implements Transaction {
+    /**
+     * The transaction expired event instance, used to perform re-aggregation
+     */
+    private final TransactionExpiredEvent event;
 
     /**
      * Primary constructor
@@ -39,6 +44,7 @@ public final class TransactionExpired extends BaseTransactionExpired implements 
             TransactionExpiredEvent event
     ) {
         super(baseTransaction, event.getData());
+        this.event = event;
     }
 
     /**
@@ -51,6 +57,20 @@ public final class TransactionExpired extends BaseTransactionExpired implements 
                     this.getTransactionAtPreviousState(),
                     transactionRefundRequestedEvent
             );
+        }
+        /*
+         * in case of closure synthetic event the transaction will remain in EXPIRED
+         * status. the transaction at previous state aggregate is recalculated applying
+         * the closure synthetic event to effectively recalculate aggregate. This logic
+         * reflects the fact that a transaction can recover from EXPIRED status with an
+         * addUserReceipt request from Nodo and should handle closed transactions coming
+         * from both close event and synthetic one but the closure event itself.
+         */
+        if (event instanceof TransactionClosureSyntheticEvent transactionClosureSyntheticEvent) {
+            BaseTransactionWithRequestedAuthorization transactionAtPreviousState = this.getTransactionAtPreviousState();
+            BaseTransactionWithRequestedAuthorization recalculatedBaseTransaction = (BaseTransactionWithRequestedAuthorization) ((Transaction) transactionAtPreviousState)
+                    .applyEvent(transactionClosureSyntheticEvent);
+            return new TransactionExpired(recalculatedBaseTransaction, this.event);
         }
 
         if (event instanceof TransactionUserReceiptRequestedEvent transactionUserReceiptRequestedEvent &&

--- a/src/main/java/it/pagopa/ecommerce/commons/domain/v2/pojos/BaseTransaction.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/domain/v2/pojos/BaseTransaction.java
@@ -6,10 +6,13 @@ import it.pagopa.ecommerce.commons.documents.v2.TransactionActivatedEvent;
 import it.pagopa.ecommerce.commons.domain.Confidential;
 import it.pagopa.ecommerce.commons.domain.v2.Email;
 import it.pagopa.ecommerce.commons.domain.v2.PaymentNotice;
-import it.pagopa.ecommerce.commons.domain.v2.TransactionId;
 import it.pagopa.ecommerce.commons.domain.v2.Transaction;
+import it.pagopa.ecommerce.commons.domain.v2.TransactionId;
 import it.pagopa.ecommerce.commons.generated.server.model.TransactionStatusDto;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 import lombok.experimental.FieldDefaults;
 
 import java.time.ZonedDateTime;

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v2/TransactionTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v2/TransactionTest.java
@@ -18,8 +18,7 @@ import reactor.test.StepVerifier;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class TransactionTest {
     @Test
@@ -6171,6 +6170,252 @@ class TransactionTest {
 
         StepVerifier.create(actual)
                 .assertNext(next -> assertEquals(expected, next))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldConstructTransactionExpiredAggregateWithClosedTransactionBeforeExpirationForClosureSyntheticEvent() {
+        EmptyTransaction transaction = new EmptyTransaction();
+
+        TransactionActivatedEvent transactionActivatedEvent = TransactionTestUtils.transactionActivateEvent();
+        TransactionAuthorizationRequestedEvent authorizationRequestedEvent = TransactionTestUtils
+                .transactionAuthorizationRequestedEvent();
+        TransactionAuthorizationCompletedEvent authorizedEvent = TransactionTestUtils
+                .transactionAuthorizationCompletedEvent(
+                        TransactionTestUtils.redirectTransactionGatewayAuthorizationData(
+                                RedirectTransactionGatewayAuthorizationData.Outcome.OK,
+                                null
+                        )
+                );
+        TransactionClosureRequestedEvent closureRequestedEvent = TransactionTestUtils
+                .transactionClosureRequestedEvent();
+        TransactionClosureSyntheticEvent closureSyntheticEvent = TransactionTestUtils
+                .transactionClosureSyntheticEvent();
+        TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils.transactionExpiredEvent(
+                TransactionTestUtils.reduceEvents(
+                        transactionActivatedEvent,
+                        authorizationRequestedEvent,
+                        authorizedEvent,
+                        closureRequestedEvent
+                )
+        );
+        Flux<Object> events = Flux.just(
+                transactionActivatedEvent,
+                authorizationRequestedEvent,
+                authorizedEvent,
+                closureRequestedEvent,
+                transactionExpiredEvent,
+                closureSyntheticEvent
+        );
+
+        TransactionActivated transactionActivated = TransactionTestUtils
+                .transactionActivated(transactionActivatedEvent.getCreationDate());
+        TransactionWithRequestedAuthorization transactionWithRequestedAuthorization = TransactionTestUtils
+                .transactionWithRequestedAuthorization(authorizationRequestedEvent, transactionActivated);
+
+        TransactionAuthorizationCompleted transactionAuthorizationCompleted = TransactionTestUtils
+                .transactionAuthorizationCompleted(
+                        authorizedEvent,
+                        transactionWithRequestedAuthorization
+                );
+        TransactionWithClosureRequested transactionWithClosureRequested = TransactionTestUtils
+                .transactionWithClosureRequested(
+                        transactionAuthorizationCompleted
+                );
+        TransactionClosed transactionClosed = TransactionTestUtils
+                .transactionClosed(
+
+                        transactionWithClosureRequested,
+                        closureSyntheticEvent
+                );
+        TransactionExpired expected = TransactionTestUtils
+                .transactionExpired(
+                        transactionClosed,
+                        transactionExpiredEvent
+                );
+
+        Mono<it.pagopa.ecommerce.commons.domain.v2.Transaction> actual = events
+                .reduce(transaction, it.pagopa.ecommerce.commons.domain.v2.Transaction::applyEvent);
+
+        StepVerifier.create(actual)
+                .assertNext(
+                        t -> {
+                            TransactionExpired transactionExpired = (TransactionExpired) t;
+                            assertEquals(expected, transactionExpired);
+                            assertEquals(TransactionStatusDto.EXPIRED, transactionExpired.getStatus());
+                            assertInstanceOf(
+                                    TransactionClosed.class,
+                                    transactionExpired.getTransactionAtPreviousState()
+                            );
+                            assertEquals(
+                                    TransactionClosureData.Outcome.OK,
+                                    ((TransactionClosed) transactionExpired.getTransactionAtPreviousState())
+                                            .getTransactionClosureData().getResponseOutcome()
+                            );
+                        }
+                )
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldConstructTransactionWithUserReceiptRecoveringFromExpiredTransactionForSyntheticClosureStartingFromClosureRequested() {
+        EmptyTransaction transaction = new EmptyTransaction();
+
+        TransactionActivatedEvent transactionActivatedEvent = TransactionTestUtils.transactionActivateEvent();
+        TransactionAuthorizationRequestedEvent authorizationRequestedEvent = TransactionTestUtils
+                .transactionAuthorizationRequestedEvent();
+        TransactionAuthorizationCompletedEvent authorizedEvent = TransactionTestUtils
+                .transactionAuthorizationCompletedEvent(
+                        TransactionTestUtils.redirectTransactionGatewayAuthorizationData(
+                                RedirectTransactionGatewayAuthorizationData.Outcome.OK,
+                                null
+                        )
+                );
+        TransactionClosureRequestedEvent closureRequestedEvent = TransactionTestUtils
+                .transactionClosureRequestedEvent();
+        TransactionClosureSyntheticEvent closureSyntheticEvent = TransactionTestUtils
+                .transactionClosureSyntheticEvent();
+        TransactionUserReceiptRequestedEvent addUserReceiptEvent = TransactionTestUtils
+                .transactionUserReceiptRequestedEvent(
+                        TransactionTestUtils.transactionUserReceiptData(TransactionUserReceiptData.Outcome.OK)
+                );
+        TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils.transactionExpiredEvent(
+                TransactionTestUtils.reduceEvents(
+                        transactionActivatedEvent,
+                        authorizationRequestedEvent,
+                        authorizedEvent,
+                        closureRequestedEvent
+                )
+        );
+        Flux<Object> events = Flux.just(
+                transactionActivatedEvent,
+                authorizationRequestedEvent,
+                authorizedEvent,
+                closureRequestedEvent,
+                transactionExpiredEvent,
+                closureSyntheticEvent,
+                addUserReceiptEvent
+        );
+
+        TransactionActivated transactionActivated = TransactionTestUtils
+                .transactionActivated(transactionActivatedEvent.getCreationDate());
+        TransactionWithRequestedAuthorization transactionWithRequestedAuthorization = TransactionTestUtils
+                .transactionWithRequestedAuthorization(authorizationRequestedEvent, transactionActivated);
+
+        TransactionAuthorizationCompleted transactionAuthorizationCompleted = TransactionTestUtils
+                .transactionAuthorizationCompleted(
+                        authorizedEvent,
+                        transactionWithRequestedAuthorization
+                );
+        TransactionWithClosureRequested transactionWithClosureRequested = TransactionTestUtils
+                .transactionWithClosureRequested(
+                        transactionAuthorizationCompleted
+                );
+        TransactionClosed transactionClosed = TransactionTestUtils
+                .transactionClosed(
+
+                        transactionWithClosureRequested,
+                        closureSyntheticEvent
+                );
+        TransactionWithRequestedUserReceipt expected = TransactionTestUtils
+                .transactionWithRequestedUserReceipt(
+                        transactionClosed,
+                        addUserReceiptEvent
+                );
+
+        Mono<it.pagopa.ecommerce.commons.domain.v2.Transaction> actual = events
+                .reduce(transaction, it.pagopa.ecommerce.commons.domain.v2.Transaction::applyEvent);
+
+        StepVerifier.create(actual)
+                .expectNextMatches(
+                        t -> {
+                            TransactionWithRequestedUserReceipt transactionUserReceiptRequested = (TransactionWithRequestedUserReceipt) t;
+                            return expected.equals(transactionUserReceiptRequested);
+
+                        }
+                )
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldConstructTransactionWithUserReceiptRecoveringFromExpiredTransactionForSyntheticClosureStartingFromClosureError() {
+        EmptyTransaction transaction = new EmptyTransaction();
+
+        TransactionActivatedEvent transactionActivatedEvent = TransactionTestUtils.transactionActivateEvent();
+        TransactionAuthorizationRequestedEvent authorizationRequestedEvent = TransactionTestUtils
+                .transactionAuthorizationRequestedEvent();
+        TransactionAuthorizationCompletedEvent authorizedEvent = TransactionTestUtils
+                .transactionAuthorizationCompletedEvent(
+                        TransactionTestUtils.redirectTransactionGatewayAuthorizationData(
+                                RedirectTransactionGatewayAuthorizationData.Outcome.OK,
+                                null
+                        )
+                );
+        TransactionClosureRequestedEvent closureRequestedEvent = TransactionTestUtils
+                .transactionClosureRequestedEvent();
+        TransactionClosureSyntheticEvent closureSyntheticEvent = TransactionTestUtils
+                .transactionClosureSyntheticEvent();
+        TransactionClosureErrorEvent closureErrorEvent = TransactionTestUtils.transactionClosureErrorEvent();
+        TransactionUserReceiptRequestedEvent addUserReceiptEvent = TransactionTestUtils
+                .transactionUserReceiptRequestedEvent(
+                        TransactionTestUtils.transactionUserReceiptData(TransactionUserReceiptData.Outcome.OK)
+                );
+        TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils.transactionExpiredEvent(
+                TransactionTestUtils.reduceEvents(
+                        transactionActivatedEvent,
+                        authorizationRequestedEvent,
+                        authorizedEvent,
+                        closureRequestedEvent
+                )
+        );
+        Flux<Object> events = Flux.just(
+                transactionActivatedEvent,
+                authorizationRequestedEvent,
+                authorizedEvent,
+                closureRequestedEvent,
+                closureErrorEvent,
+                transactionExpiredEvent,
+                closureSyntheticEvent,
+                addUserReceiptEvent
+        );
+
+        TransactionActivated transactionActivated = TransactionTestUtils
+                .transactionActivated(transactionActivatedEvent.getCreationDate());
+        TransactionWithRequestedAuthorization transactionWithRequestedAuthorization = TransactionTestUtils
+                .transactionWithRequestedAuthorization(authorizationRequestedEvent, transactionActivated);
+
+        TransactionAuthorizationCompleted transactionAuthorizationCompleted = TransactionTestUtils
+                .transactionAuthorizationCompleted(
+                        authorizedEvent,
+                        transactionWithRequestedAuthorization
+                );
+        TransactionWithClosureRequested transactionWithClosureRequested = TransactionTestUtils
+                .transactionWithClosureRequested(
+                        transactionAuthorizationCompleted
+                );
+        TransactionClosed transactionClosed = TransactionTestUtils
+                .transactionClosed(
+
+                        transactionWithClosureRequested,
+                        closureSyntheticEvent
+                );
+        TransactionWithRequestedUserReceipt expected = TransactionTestUtils
+                .transactionWithRequestedUserReceipt(
+                        transactionClosed,
+                        addUserReceiptEvent
+                );
+
+        Mono<it.pagopa.ecommerce.commons.domain.v2.Transaction> actual = events
+                .reduce(transaction, it.pagopa.ecommerce.commons.domain.v2.Transaction::applyEvent);
+
+        StepVerifier.create(actual)
+                .expectNextMatches(
+                        t -> {
+                            TransactionWithRequestedUserReceipt transactionUserReceiptRequested = (TransactionWithRequestedUserReceipt) t;
+                            return expected.equals(transactionUserReceiptRequested);
+
+                        }
+                )
                 .verifyComplete();
     }
 }

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v2/TransactionTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v2/TransactionTest.java
@@ -6222,16 +6222,11 @@ class TransactionTest {
                 .transactionWithClosureRequested(
                         transactionAuthorizationCompleted
                 );
-        TransactionClosed transactionClosed = TransactionTestUtils
+        TransactionClosed expected = TransactionTestUtils
                 .transactionClosed(
 
                         transactionWithClosureRequested,
                         closureSyntheticEvent
-                );
-        TransactionExpired expected = TransactionTestUtils
-                .transactionExpired(
-                        transactionClosed,
-                        transactionExpiredEvent
                 );
 
         Mono<it.pagopa.ecommerce.commons.domain.v2.Transaction> actual = events
@@ -6240,16 +6235,12 @@ class TransactionTest {
         StepVerifier.create(actual)
                 .assertNext(
                         t -> {
-                            TransactionExpired transactionExpired = (TransactionExpired) t;
-                            assertEquals(expected, transactionExpired);
-                            assertEquals(TransactionStatusDto.EXPIRED, transactionExpired.getStatus());
-                            assertInstanceOf(
-                                    TransactionClosed.class,
-                                    transactionExpired.getTransactionAtPreviousState()
-                            );
+                            TransactionClosed trxClosed = (TransactionClosed) t;
+                            assertEquals(expected, trxClosed);
+                            assertEquals(TransactionStatusDto.CLOSED, trxClosed.getStatus());
                             assertEquals(
                                     TransactionClosureData.Outcome.OK,
-                                    ((TransactionClosed) transactionExpired.getTransactionAtPreviousState())
+                                    trxClosed
                                             .getTransactionClosureData().getResponseOutcome()
                             );
                         }

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v2/TransactionTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v2/TransactionTest.java
@@ -6411,7 +6411,7 @@ class TransactionTest {
     }
 
     @Test
-    void shouldIgnoreTransactionClosureSyntheticEventForExpiredTransactionWhereBeforeExpirationTransactionRejectEvents() {
+    void shouldIgnoreTransactionClosureSyntheticEventForExpiredTransactionWhereBeforeExpirationTransactionIsNotClosureRequested() {
         EmptyTransaction transaction = new EmptyTransaction();
 
         TransactionActivatedEvent transactionActivatedEvent = TransactionTestUtils.transactionActivateEvent();
@@ -6471,6 +6471,74 @@ class TransactionTest {
                                     TransactionAuthorizationCompleted.class,
                                     transactionExpired.getTransactionAtPreviousState()
                             );
+
+                        }
+                )
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldRejectClosureSyntheticEventForTransactionThatWasNotAuthorized() {
+        EmptyTransaction transaction = new EmptyTransaction();
+
+        TransactionActivatedEvent transactionActivatedEvent = TransactionTestUtils.transactionActivateEvent();
+        TransactionAuthorizationRequestedEvent authorizationRequestedEvent = TransactionTestUtils
+                .transactionAuthorizationRequestedEvent();
+        TransactionAuthorizationCompletedEvent authorizedEvent = TransactionTestUtils
+                .transactionAuthorizationCompletedEvent(
+                        TransactionTestUtils.redirectTransactionGatewayAuthorizationData(
+                                RedirectTransactionGatewayAuthorizationData.Outcome.KO,
+                                null
+                        )
+                );
+        TransactionClosureRequestedEvent closureRequestedEvent = TransactionTestUtils
+                .transactionClosureRequestedEvent();
+        TransactionClosureSyntheticEvent closureSyntheticEvent = TransactionTestUtils
+                .transactionClosureSyntheticEvent();
+        TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils.transactionExpiredEvent(
+                TransactionTestUtils.reduceEvents(
+                        transactionActivatedEvent,
+                        authorizationRequestedEvent,
+                        authorizedEvent,
+                        closureRequestedEvent
+                )
+        );
+        Flux<Object> events = Flux.just(
+                transactionActivatedEvent,
+                authorizationRequestedEvent,
+                authorizedEvent,
+                closureRequestedEvent,
+                transactionExpiredEvent,
+                closureSyntheticEvent
+        );
+
+        TransactionActivated transactionActivated = TransactionTestUtils
+                .transactionActivated(transactionActivatedEvent.getCreationDate());
+        TransactionWithRequestedAuthorization transactionWithRequestedAuthorization = TransactionTestUtils
+                .transactionWithRequestedAuthorization(authorizationRequestedEvent, transactionActivated);
+
+        TransactionAuthorizationCompleted transactionAuthorizationCompleted = TransactionTestUtils
+                .transactionAuthorizationCompleted(
+                        authorizedEvent,
+                        transactionWithRequestedAuthorization
+                );
+        TransactionWithClosureRequested transactionWithClosureRequested = TransactionTestUtils
+                .transactionWithClosureRequested(
+                        transactionAuthorizationCompleted
+                );
+
+        TransactionExpired expected = TransactionTestUtils.transactionExpired(
+                transactionWithClosureRequested,
+                transactionExpiredEvent
+        );
+
+        Mono<it.pagopa.ecommerce.commons.domain.v2.Transaction> actual = events
+                .reduce(transaction, it.pagopa.ecommerce.commons.domain.v2.Transaction::applyEvent);
+
+        StepVerifier.create(actual)
+                .assertNext(
+                        t -> {
+                            assertEquals(expected, t);
 
                         }
                 )

--- a/src/test/java/it/pagopa/ecommerce/commons/domain/v2/TransactionTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/domain/v2/TransactionTest.java
@@ -6418,4 +6418,71 @@ class TransactionTest {
                 )
                 .verifyComplete();
     }
+
+    @Test
+    void shouldIgnoreTransactionClosureSyntheticEventForExpiredTransactionWhereBeforeExpirationTransactionRejectEvents() {
+        EmptyTransaction transaction = new EmptyTransaction();
+
+        TransactionActivatedEvent transactionActivatedEvent = TransactionTestUtils.transactionActivateEvent();
+        TransactionAuthorizationRequestedEvent authorizationRequestedEvent = TransactionTestUtils
+                .transactionAuthorizationRequestedEvent();
+        TransactionAuthorizationCompletedEvent authorizedEvent = TransactionTestUtils
+                .transactionAuthorizationCompletedEvent(
+                        TransactionTestUtils.redirectTransactionGatewayAuthorizationData(
+                                RedirectTransactionGatewayAuthorizationData.Outcome.OK,
+                                null
+                        )
+                );
+        TransactionClosureSyntheticEvent closureSyntheticEvent = TransactionTestUtils
+                .transactionClosureSyntheticEvent();
+
+        TransactionExpiredEvent transactionExpiredEvent = TransactionTestUtils.transactionExpiredEvent(
+                TransactionTestUtils.reduceEvents(
+                        transactionActivatedEvent,
+                        authorizationRequestedEvent,
+                        authorizedEvent
+                )
+        );
+        Flux<Object> events = Flux.just(
+                transactionActivatedEvent,
+                authorizationRequestedEvent,
+                authorizedEvent,
+                transactionExpiredEvent,
+                closureSyntheticEvent
+        );
+
+        TransactionActivated transactionActivated = TransactionTestUtils
+                .transactionActivated(transactionActivatedEvent.getCreationDate());
+        TransactionWithRequestedAuthorization transactionWithRequestedAuthorization = TransactionTestUtils
+                .transactionWithRequestedAuthorization(authorizationRequestedEvent, transactionActivated);
+
+        TransactionAuthorizationCompleted transactionAuthorizationCompleted = TransactionTestUtils
+                .transactionAuthorizationCompleted(
+                        authorizedEvent,
+                        transactionWithRequestedAuthorization
+                );
+
+        TransactionExpired expected = TransactionTestUtils
+                .transactionExpired(
+                        transactionAuthorizationCompleted,
+                        transactionExpiredEvent
+                );
+
+        Mono<it.pagopa.ecommerce.commons.domain.v2.Transaction> actual = events
+                .reduce(transaction, it.pagopa.ecommerce.commons.domain.v2.Transaction::applyEvent);
+
+        StepVerifier.create(actual)
+                .assertNext(
+                        t -> {
+                            TransactionExpired transactionExpired = (TransactionExpired) t;
+                            assertEquals(expected, transactionExpired);
+                            assertInstanceOf(
+                                    TransactionAuthorizationCompleted.class,
+                                    transactionExpired.getTransactionAtPreviousState()
+                            );
+
+                        }
+                )
+                .verifyComplete();
+    }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Handle closure synthetic event in TransactionExpired aggregate: closure synthetic event will produce a TransactionExpired aggregate too (aka transaction will remain in expired status) with transactionAtPreviousStep set as result of closure synthetic event being applied to previous transaction aggregate
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is required since add user receipt can be handled starting from both `CLOSED` and `EXPIRED` statuses.
In case of EXPIRED statuses check are performed against the "before expiration" aggregate.
In order to reuse check logic if a closure synthetic event is received for a transaction in EXPIRED status the event is applied to the aggregate before expiration making state transition (if the before expiration status is in the right status to accept closure synthetic event) and return the transaction in CLOSED status, ready to process the add user receipt one
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.