### PR TITLE
feat: add support for overlapping configuration

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/utils/RedirectUrlMappingConf.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/RedirectUrlMappingConf.java
@@ -10,9 +10,9 @@ import it.pagopa.ecommerce.commons.exceptions.RedirectConfigurationType;
 import it.pagopa.ecommerce.commons.utils.bean.redirect.configuration.RedirectUrlMappingCriteria;
 import it.pagopa.ecommerce.commons.utils.bean.redirect.configuration.RedirectUrlMappingEntry;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -88,7 +88,7 @@ public class RedirectUrlMappingConf {
     public Either<RedirectConfigurationException, RedirectUrlMappingEntry> getRedirectUrlForCriteria(
                                                                                                      Map<RedirectUrlMappingCriteria, String> searchCriteria
     ) {
-        Map<Integer, List<RedirectUrlMappingEntry>> rankedConfMatches = urlConfiguration.stream()
+        TreeMap<Integer, List<RedirectUrlMappingEntry>> rankedConfMatches = urlConfiguration.stream()
                 .filter(
                         confEntry -> searchCriteria.entrySet().stream()
                                 .allMatch(
@@ -113,11 +113,13 @@ public class RedirectUrlMappingConf {
                                         }
                                     }
                                     return matchingCriteriaCount;
-                                }
+                                },
+                                TreeMap::new,
+                                Collectors.toList()
                         )
                 );
         List<RedirectUrlMappingEntry> entries = rankedConfMatches.isEmpty() ? List.of()
-                : rankedConfMatches.get(Collections.max(rankedConfMatches.keySet()));
+                : rankedConfMatches.get(rankedConfMatches.lastKey());
         if (entries.size() != 1) {
             String errorMessageHeader = entries.isEmpty() ? "No configuration found"
                     : "Multiple configurations found: %s".formatted(entries);

--- a/src/main/java/it/pagopa/ecommerce/commons/utils/RedirectUrlMappingConf.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/utils/RedirectUrlMappingConf.java
@@ -10,9 +10,11 @@ import it.pagopa.ecommerce.commons.exceptions.RedirectConfigurationType;
 import it.pagopa.ecommerce.commons.utils.bean.redirect.configuration.RedirectUrlMappingCriteria;
 import it.pagopa.ecommerce.commons.utils.bean.redirect.configuration.RedirectUrlMappingEntry;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Class used to handle redirect payment methods url configuration and search
@@ -79,16 +81,16 @@ public class RedirectUrlMappingConf {
     /**
      * Retrieve url configuration that matches input search criteria
      *
-     * @param matchingCriteria - the search matching criteria
+     * @param searchCriteria - the search matching criteria
      * @return Either the fetched configuration or error in case of
      *         missing/ambiguous search result
      */
     public Either<RedirectConfigurationException, RedirectUrlMappingEntry> getRedirectUrlForCriteria(
-                                                                                                     Map<RedirectUrlMappingCriteria, String> matchingCriteria
+                                                                                                     Map<RedirectUrlMappingCriteria, String> searchCriteria
     ) {
-        List<RedirectUrlMappingEntry> entries = urlConfiguration.stream()
+        Map<Integer, List<RedirectUrlMappingEntry>> rankedConfMatches = urlConfiguration.stream()
                 .filter(
-                        confEntry -> matchingCriteria.entrySet().stream()
+                        confEntry -> searchCriteria.entrySet().stream()
                                 .allMatch(
                                         entry -> confEntry
                                                 .matchingCriteria()
@@ -98,17 +100,32 @@ public class RedirectUrlMappingConf {
                                                 .getOrDefault(entry.getKey(), entry.getValue())
                                                 .equals(entry.getValue())
                                 )
-                )
-                .toList();
+                ).collect(
+                        Collectors.groupingBy(
+                                entry -> {
+                                    int matchingCriteriaCount = 0;
+                                    for (Map.Entry<RedirectUrlMappingCriteria, String> criteria : searchCriteria
+                                            .entrySet()) {
+                                        if (criteria.getValue().equals(
+                                                entry.matchingCriteria().getOrDefault(criteria.getKey(), null)
+                                        )) {
+                                            matchingCriteriaCount++;
+                                        }
+                                    }
+                                    return matchingCriteriaCount;
+                                }
+                        )
+                );
+        List<RedirectUrlMappingEntry> entries = rankedConfMatches.isEmpty() ? List.of()
+                : rankedConfMatches.get(Collections.max(rankedConfMatches.keySet()));
         if (entries.size() != 1) {
             String errorMessageHeader = entries.isEmpty() ? "No configuration found"
                     : "Multiple configurations found: %s".formatted(entries);
             String errorMessage = errorMessageHeader
-                    + " for the provided matching criteria: %s".formatted(matchingCriteria);
+                    + " for the provided matching criteria: %s".formatted(searchCriteria);
             return Either
                     .left(new RedirectConfigurationException(errorMessage, RedirectConfigurationType.BACKEND_URLS));
         }
         return Either.right(entries.getFirst());
     }
-
 }

--- a/src/test/java/it/pagopa/ecommerce/commons/utils/RedirectUrlMappingConfTest.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/utils/RedirectUrlMappingConfTest.java
@@ -58,6 +58,25 @@ public class RedirectUrlMappingConfTest {
             ]
             """;
 
+    private final String overlappingConf = """
+            [
+                {
+                    "url": "http://localhost/psp1",
+                    "matchingCriteria": {
+                        "PAYMENT_TYPE_CODE": "paymentTypeCode",
+                        "PSP_ID": "pspId"
+                    }
+                },
+                {
+                    "url": "http://localhost/psp2",
+                    "matchingCriteria": {
+                        "PAYMENT_TYPE_CODE": "paymentTypeCode",
+                        "PSP_ID": "pspId",
+                        "PSP_CHANNEL_ID": "channelId"
+                    }
+                }
+            ]
+            """;
     private final RedirectUrlMappingConf redirectUrlMappingConf = new RedirectUrlMappingConf(
             urlConfiguration,
             expectedMatchingCriteria
@@ -231,6 +250,45 @@ public class RedirectUrlMappingConfTest {
         assertEquals(
                 "Error parsing Redirect PSP BACKEND_URLS configuration, cause: Multiple configurations found: [RedirectUrlMappingEntry[url=http://localhost/psp2, matchingCriteria={PAYMENT_TYPE_CODE=paymentTypeCode2, PSP_ID=pspId2, PSP_CHANNEL_ID=multiMatchKey}], RedirectUrlMappingEntry[url=http://localhost/psp3, matchingCriteria={PAYMENT_TYPE_CODE=paymentTypeCode3, PSP_ID=pspId3, TOUCHPOINT=touchpoint3, PSP_CHANNEL_ID=multiMatchKey}]] for the provided matching criteria: {PSP_CHANNEL_ID=multiMatchKey}",
                 entry.getLeft().getMessage()
+        );
+    }
+
+    @Test
+    public void shouldReturnConfigurationWithHigherMatchingParametersCount() {
+
+        RedirectUrlMappingConf conf = new RedirectUrlMappingConf(overlappingConf, "[]");
+        Either<RedirectConfigurationException, RedirectUrlMappingEntry> result = conf.getRedirectUrlForCriteria(
+                Map.of(
+                        RedirectUrlMappingCriteria.PAYMENT_TYPE_CODE,
+                        "paymentTypeCode",
+                        RedirectUrlMappingCriteria.PSP_ID,
+                        "pspId",
+                        RedirectUrlMappingCriteria.PSP_CHANNEL_ID,
+                        "channelId"
+                )
+        );
+        assertTrue(result.isRight());
+        assertEquals("http://localhost/psp2", result.get().url().toString());
+    }
+
+    @Test
+    public void shouldReturnErrorForConfigurationWithSameMatchingParametersCount() {
+
+        RedirectUrlMappingConf conf = new RedirectUrlMappingConf(overlappingConf, "[]");
+        Either<RedirectConfigurationException, RedirectUrlMappingEntry> result = conf.getRedirectUrlForCriteria(
+                Map.of(
+                        RedirectUrlMappingCriteria.PAYMENT_TYPE_CODE,
+                        "paymentTypeCode",
+                        RedirectUrlMappingCriteria.PSP_ID,
+                        "pspId"
+                )
+        );
+        assertTrue(result.isLeft());
+        assertTrue(
+                result.getLeft().getMessage().startsWith(
+                        "Error parsing Redirect PSP BACKEND_URLS configuration, cause: Multiple configurations found"
+                )
+
         );
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add support for overlapping redirect configurations adding logic to return the configuration.
This have been done adding a configuration ranking based on the number of exact search matching criteria count and returning the configuration with the higher number, if this is unique
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is required to handle partial configuration overlap.
For Poste PSP the actual situation is the following:
|#| pspId | payment type code | channelId | touchpoint | description |
|-|-------|---------------------|----------| ---|---|
|0| BPPIITRRXXX| RBPR| - | - | configuration as is that will remain untouched |
|1| BPPIITRRXXX| RBPP| - | - |configuration as is that will remain untouched |
|2| BPPIITRRXXX| RBPB| - | - |configuration as is that will remain untouched|
|3| PPAYITR1XXX| RBPB| - | - |configuration as is  to be migrated under BPPIITRRXXX with channel discrimination add |
|4| PPAYITR1XXX| RBPP| - | CHECKOUT |configuration as is  to be migrated under BPPIITRRXXX with channel discrimination add |
|5| PPAYITR1XXX| RBPB| - | IO|configuration as is to be migrated under BPPIITRRXXX with channel discrimination add |
|6| PPAYITR1XXX| RBPR| - | - |configuration as is  to be migrated under BPPIITRRXXX with channel discrimination add |
|7|BPPIITRRXXX| RBPB| aaa | - | migrated configuration from above to BPPIITRRXXX, partial overlap with existent configuration |
|8|BPPIITRRXXX| RBPP| bbb | CHECKOUT | migrated configuration from above to BPPIITRRXXX, partial overlap with existent configuration |
|9|BPPIITRRXXX| RBPP| ccc | IO | migrated configuration from above to BPPIITRRXXX, partial overlap with existent configuration |
|10|BPPIITRRXXX| RBPR| ddd | - | migrated configuration from above to BPPIITRRXXX, partial overlap with existent configuration |

the last four lines refers to the "migrated" configurations that have to be loaded in memory during switch, in order to make switch operation a zero downtime operation.
In the previous implementation a searching key for the following parameters:
pspId = BPPIITRRXXX 
paymentTypeCode = RBPP 
channelId =  bbb  
touchpoint = CHECKOUT 

would have matched two entries, the # 1 and the # 8, returning error to the caller because of ambiguity in configuration.

With this implementation only the # 8 will be returned since it has 4 exact matches in place of the 2 of the # 1, allowing for configuration overlap.

In the case of multiple entries with same number of exact match an error will be raised as previously done
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.