### PR TITLE
fix(tracing-utils): [CHK-4873] improve tracing context handling

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/queues/TracingUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/queues/TracingUtils.java
@@ -135,20 +135,26 @@ public class TracingUtils {
     /**
      * <p>
      * Wraps a {@link Mono} with a new {@link Span} with name {@code spanName}. The
-     * new span is created with a link to a remote span whose tracing data is
-     * extracted from {@code tracingInfo}.
+     * new span is created as a child of the remote span whose tracing data is
+     * extracted from {@code tracingInfo}, ensuring each processed message continues
+     * the producer's trace (same {@code trace.id}) rather than inheriting any
+     * ambient thread context.
+     * </p>
+     * <p>
+     * When {@code tracingInfo} is {@code null} (e.g. for legacy untraced events) a
+     * fresh root span is created instead.
      * </p>
      *
-     * @param tracingInfo tracing info to reconstruct the remote span to be linked
-     *                    to
+     * @param tracingInfo tracing info carrying the remote span context to use as
+     *                    parent, or {@code null} to start a new root trace
      * @param spanName    name of the new span
      * @param operation   {@link Mono} that will be wrapped
-     * @return a new {@link Mono} with a span linked to the remote span identified
-     *         by {@code tracingInfo}
+     * @return a new {@link Mono} whose span is a child of the remote span
+     *         identified by {@code tracingInfo}
      * @param <T> type parameter for the original {@link Mono}
      */
     public <T> @NonNull Mono<T> traceMonoWithRemoteSpan(
-                                                        @NonNull TracingInfo tracingInfo,
+                                                        @Nullable TracingInfo tracingInfo,
                                                         @NonNull String spanName,
                                                         @NonNull Mono<T> operation
     ) {
@@ -158,44 +164,47 @@ public class TracingUtils {
     }
 
     private @NonNull Span createSpanWithRemoteTracingContext(
-                                                             @NonNull TracingInfo tracingInfo,
+                                                             @Nullable TracingInfo tracingInfo,
                                                              @NonNull String spanName
     ) {
         logger.debug("Creating Span with remote tracing context: {}", tracingInfo);
 
-        Context extractedContext = openTelemetry.getPropagators().getTextMapPropagator().extract(
-                Context.current(),
-                tracingInfo,
-                new TextMapGetter<>() {
-                    @Override
-                    public Iterable<String> keys(@Nonnull TracingInfo tracingInfo) {
-                        return Set.of(TRACEPARENT, TRACESTATE, BAGGAGE);
-                    }
+        Context parentContext;
+        if (tracingInfo != null) {
+            parentContext = openTelemetry.getPropagators().getTextMapPropagator().extract(
+                    Context.root(),
+                    tracingInfo,
+                    new TextMapGetter<>() {
+                        @Override
+                        public Iterable<String> keys(@Nonnull TracingInfo carrier) {
+                            return Set.of(TRACEPARENT, TRACESTATE, BAGGAGE);
+                        }
 
-                    @Nullable
-                    @Override
-                    public String get(
-                                      @Nullable TracingInfo tracingInfo,
-                                      @Nonnull String key
-                    ) {
-                        return switch (key) {
-                            case TRACEPARENT -> Optional.ofNullable(tracingInfo).map(TracingInfo::getTraceparent)
-                                    .orElse(null);
-                            case TRACESTATE -> Optional.ofNullable(tracingInfo).flatMap(TracingInfo::getTracestate)
-                                    .orElse(null);
-                            case BAGGAGE -> Optional.ofNullable(tracingInfo).flatMap(TracingInfo::getBaggage)
-                                    .orElse(null);
-                            default -> null;
-                        };
+                        @Nullable
+                        @Override
+                        public String get(
+                                          @Nullable TracingInfo carrier,
+                                          @Nonnull String key
+                        ) {
+                            return switch (key) {
+                                case TRACEPARENT -> Optional.ofNullable(carrier).map(TracingInfo::getTraceparent)
+                                        .orElse(null);
+                                case TRACESTATE -> Optional.ofNullable(carrier).flatMap(TracingInfo::getTracestate)
+                                        .orElse(null);
+                                case BAGGAGE -> Optional.ofNullable(carrier).flatMap(TracingInfo::getBaggage)
+                                        .orElse(null);
+                                default -> null;
+                            };
+                        }
                     }
-                }
-        );
-
+            );
+        } else {
+            parentContext = Context.root();
+        }
         return tracer
                 .spanBuilder(spanName)
                 .setSpanKind(SpanKind.CONSUMER)
-                .setParent(Context.current().with(Span.current()))
-                .addLink(Span.fromContext(extractedContext).getSpanContext())
+                .setParent(parentContext)
                 .startSpan();
     }
 

--- a/src/main/java/it/pagopa/ecommerce/commons/queues/TracingUtils.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/queues/TracingUtils.java
@@ -137,12 +137,11 @@ public class TracingUtils {
      * Wraps a {@link Mono} with a new {@link Span} with name {@code spanName}. The
      * new span is created as a child of the remote span whose tracing data is
      * extracted from {@code tracingInfo}, ensuring each processed message continues
-     * the producer's trace (same {@code trace.id}) rather than inheriting any
-     * ambient thread context.
+     * the producer's trace (same {@code trace.id}).
      * </p>
      * <p>
-     * When {@code tracingInfo} is {@code null} (e.g. for legacy untraced events) a
-     * fresh root span is created instead.
+     * When {@code tracingInfo} is {@code null} a fresh root span is created
+     * instead.
      * </p>
      *
      * @param tracingInfo tracing info carrying the remote span context to use as

--- a/src/test/java/it/pagopa/ecommerce/commons/queues/TracingUtilsTests.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/queues/TracingUtilsTests.java
@@ -2,7 +2,6 @@ package it.pagopa.ecommerce.commons.queues;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
@@ -10,8 +9,6 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -79,6 +76,26 @@ public class TracingUtilsTests {
         Mono<Integer> operation = Mono.error(expected);
 
         StepVerifier.create(tracingUtils.traceMonoWithRemoteSpan(MOCK_TRACING_INFO, "test", operation))
+                .expectErrorMatches(e -> e.equals(expected))
+                .verify();
+    }
+
+    @Test
+    void traceMonoWithRemoteSpanWithNullTracingInfoReturnsValue() {
+        int expected = 0;
+        Mono<Integer> operation = Mono.just(expected);
+
+        StepVerifier.create(tracingUtils.traceMonoWithRemoteSpan(null, "test", operation))
+                .expectNext(expected)
+                .verifyComplete();
+    }
+
+    @Test
+    void traceMonoWithRemoteSpanWithNullTracingInfoPropagatesError() {
+        RuntimeException expected = new RuntimeException("error!");
+        Mono<Integer> operation = Mono.error(expected);
+
+        StepVerifier.create(tracingUtils.traceMonoWithRemoteSpan(null, "test", operation))
                 .expectErrorMatches(e -> e.equals(expected))
                 .verify();
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Updated `traceMonoWithRemoteSpan` method (only used by **pagopa-ecommerce-event-dispatcher-service**) to correctly set the span's parent
- Added unit test

#### Motivation and Context

The goal is to fix a problem where multiple traces sent by the service shared the same trace.id, resulting in incomplete traces and the following error "The number of items in this trace is x which is higher than the current limit of 5000". This fix also solves the same problem on **pagopa-notifications-service** which was caused by the trace.id received by the ecommerce event-dispatcher service.

Examples of traces on ecommerce-event-dispatcher before/after the change:

**TransactionsRefundQueueConsumer**

Before:
<img width="2198" height="1080" alt="image" src="https://github.com/user-attachments/assets/e03e4556-9e0a-49bd-a174-ab3643a70dbb" />

After:
<img width="2203" height="372" alt="image" src="https://github.com/user-attachments/assets/c065a23f-c32b-457f-97c5-f55b8b2c79ab" />

---
**TransactionNotificationsQueueConsumer**

Before:
<img width="2203" height="159" alt="image" src="https://github.com/user-attachments/assets/edec79fb-6148-4896-8d98-a3f18da4e723" />

After:
<img width="2203" height="916" alt="image" src="https://github.com/user-attachments/assets/7bac94ec-4018-4814-8bac-b78b6883533b" />

---
**ClosePaymentHelper**

Before:
<img width="2203" height="580" alt="image" src="https://github.com/user-attachments/assets/e53ab45d-4f6c-4b0c-a75c-5f7010f03441" />

After:
<img width="2203" height="540" alt="image" src="https://github.com/user-attachments/assets/cff9ad5f-29aa-435f-95fc-91fa8bba8391" />

---
POST /emails on **pagopa-notifications-service**

<img width="2203" height="591" alt="image" src="https://github.com/user-attachments/assets/2ded56b6-a52b-4ddc-833f-7e4e19c828ac" />



#### How Has This Been Tested?

- Unit tests
- DEV env tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.