### PR TITLE
[PIDM-2143] chore: remove unused commons-lang 2.6 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,11 +128,6 @@
             <version>1.16.0</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
-        </dependency>
-        <dependency>
             <groupId>io.vavr</groupId>
             <artifactId>vavr</artifactId>
             <version>0.10.4</version>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Removed commons-lang:commons-lang:2.6 dependency from pom.xml

#### Motivation and Context

commons-lang 2.6 is affected by security vulnerability. Codebase analysis confirmed the library is not actively used in the project, so it has been removed entirely rather than upgraded.

#### How Has This Been Tested?

- Verified via IntelliJ Find Usages that no class or method from commons-lang is imported or used in the source code
- Verified that the project compiles correctly after removal via ./mvnw compile

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.