### PR TITLE
feat: [PIDM-2191] Add methodTypeCode to enum PaymentMethod

### DIFF
--- a/src/main/java/it/pagopa/ecommerce/commons/client/NpgClient.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/client/NpgClient.java
@@ -146,6 +146,9 @@ public class NpgClient {
          */
         public final String serviceName;
 
+        /**
+         * The payment type code (e.g. "CP", "PPAL")
+         */
         public final String methodTypeCode;
 
         PaymentMethod(

--- a/src/main/java/it/pagopa/ecommerce/commons/client/NpgClient.java
+++ b/src/main/java/it/pagopa/ecommerce/commons/client/NpgClient.java
@@ -83,71 +83,77 @@ public class NpgClient {
         /**
          * Credit cards
          */
-        CARDS("CARDS"),
+        CARDS("CARDS", "CP"),
         /**
          * PayPal
          */
-        PAYPAL("PAYPAL"),
+        PAYPAL("PAYPAL", "PPAL"),
         /**
          * PayPal with Pay in 3 option
          */
-        PAYPAL_PAGAIN3("PAYPAL_PAGAIN3"),
+        PAYPAL_PAGAIN3("PAYPAL_PAGAIN3", null),
         /**
          * GiroPay
          */
-        GIROPAY("GIROPAY"),
+        GIROPAY("GIROPAY", null),
         /**
          * Ideal
          */
-        IDEAL("IDEAL"),
+        IDEAL("IDEAL", null),
         /**
          * MyBank
          */
-        MYBANK("MYBANK"),
+        MYBANK("MYBANK", "MYBK"),
         /**
          * Google Pay
          */
-        GOOGLEPAY("GOOGLEPAY"),
+        GOOGLEPAY("GOOGLEPAY", "GOOG"),
         /**
          * Apple Pay
          */
-        APPLEPAY("APPLEPAY"),
+        APPLEPAY("APPLEPAY", "APPL"),
         /**
          * Bancomat Pay
          */
-        BANCOMATPAY("BANCOMATPAY"),
+        BANCOMATPAY("BANCOMATPAY", "BPAY"),
         /**
          * Bancontact
          */
-        BANCONTACT("BANCONTACT"),
+        BANCONTACT("BANCONTACT", null),
         /**
          * Multibanco
          */
-        MULTIBANCO("MULTIBANCO"),
+        MULTIBANCO("MULTIBANCO", null),
         /**
          * WeChat
          */
-        WECHAT("WECHAT"),
+        WECHAT("WECHAT", null),
         /**
          * AliPay
          */
-        ALIPAY("ALIPAY"),
+        ALIPAY("ALIPAY", null),
         /**
          * PIS (3DS2 Payment Initiation Service)
          */
-        PIS("PIS"),
+        PIS("PIS", null),
         /**
          * Satispay direct
          */
-        SATISPAY("SATISPAY_DIRECT");
+        SATISPAY("SATISPAY_DIRECT", "SATY");
 
         /**
          * API value for `serviceName`
          */
         public final String serviceName;
 
-        PaymentMethod(String serviceName) {
+        public final String methodTypeCode;
+
+        PaymentMethod(
+                String serviceName,
+                String methodTypeCode
+        ) {
             this.serviceName = serviceName;
+            this.methodTypeCode = methodTypeCode;
         }
 
         /**
@@ -166,6 +172,29 @@ public class NpgClient {
             }
 
             throw new IllegalArgumentException("Invalid payment method service name: '%s'".formatted(serviceName));
+        }
+
+        /**
+         * Retrieves a {@link PaymentMethod} by its AFM payment type code.
+         *
+         * @param methodTypeCode the AFM payment type code (e.g. "CP", "PPAL", "BPAY")
+         * @return the corresponding payment method
+         * @throws IllegalArgumentException if no payment method exists for the given
+         *                                  type code
+         */
+        public static PaymentMethod fromMethodTypeCode(String methodTypeCode) {
+            if (methodTypeCode == null) {
+                throw new IllegalArgumentException("methodTypeCode must not be null");
+            }
+            for (PaymentMethod paymentMethod : PaymentMethod.values()) {
+                if (methodTypeCode.equals(paymentMethod.methodTypeCode)) {
+                    return paymentMethod;
+                }
+            }
+
+            throw new IllegalArgumentException(
+                    "No PaymentMethod found for methodTypeCode: '%s'".formatted(methodTypeCode)
+            );
         }
     }
 

--- a/src/test/java/it/pagopa/ecommerce/commons/client/NpgClientPaymentMethodTests.java
+++ b/src/test/java/it/pagopa/ecommerce/commons/client/NpgClientPaymentMethodTests.java
@@ -4,8 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 class NpgClientPaymentMethodTests {
@@ -17,5 +16,34 @@ class NpgClientPaymentMethodTests {
         }
         assertThrows(IllegalArgumentException.class, () -> NpgClient.PaymentMethod.fromServiceName("serviceName"));
 
+    }
+
+    @Test
+    void shouldReturnPaymentMethodFromMethodTypeCode() {
+        assertEquals(NpgClient.PaymentMethod.CARDS, NpgClient.PaymentMethod.fromMethodTypeCode("CP"));
+        assertEquals(NpgClient.PaymentMethod.PAYPAL, NpgClient.PaymentMethod.fromMethodTypeCode("PPAL"));
+        assertEquals(NpgClient.PaymentMethod.MYBANK, NpgClient.PaymentMethod.fromMethodTypeCode("MYBK"));
+        assertEquals(NpgClient.PaymentMethod.GOOGLEPAY, NpgClient.PaymentMethod.fromMethodTypeCode("GOOG"));
+        assertEquals(NpgClient.PaymentMethod.APPLEPAY, NpgClient.PaymentMethod.fromMethodTypeCode("APPL"));
+        assertEquals(NpgClient.PaymentMethod.BANCOMATPAY, NpgClient.PaymentMethod.fromMethodTypeCode("BPAY"));
+        assertEquals(NpgClient.PaymentMethod.SATISPAY, NpgClient.PaymentMethod.fromMethodTypeCode("SATY"));
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidMethodTypeCode() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> NpgClient.PaymentMethod.fromMethodTypeCode("INVALID")
+        );
+        assertTrue(exception.getMessage().contains("INVALID"));
+    }
+
+    @Test
+    void shouldThrowExceptionForNullMethodTypeCode() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> NpgClient.PaymentMethod.fromMethodTypeCode(null)
+        );
+        assertEquals("methodTypeCode must not be null", exception.getMessage());
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added methodTypeCode field to NpgClient.PaymentMethod enum

#### Motivation and Context

With the migration of `pagopa-ecommerce-payment-methods-service` from direct MongoDB reads to the `payment-methods-handler`, by adding `methodTypeCode` to the enum, consumers can resolve the `PaymentMethod` using this unique code instead of relying on display names or enum constant names.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.